### PR TITLE
Fixes pour compteurs individuels et cache arrays

### DIFF
--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from datetime import timedelta
 
 from homeassistant.components.integration.sensor import (
-    TRAPEZOIDAL_METHOD,
     LEFT_METHOD,
+    TRAPEZOIDAL_METHOD,
     IntegrationSensor,
 )
 from homeassistant.components.sensor import (

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from homeassistant.components.integration.sensor import (
-    LEFT_METHOD,
-    IntegrationSensor,
-)
+import homeassistant.util.dt as dt_util
+from homeassistant.components.integration.sensor import LEFT_METHOD, IntegrationSensor
 from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
     STATE_CLASS_TOTAL_INCREASING,
@@ -36,7 +34,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import Throttle, slugify
-import homeassistant.util.dt as dt_util
 from pyhilo.device import HiloDevice
 from pyhilo.event import Event
 from pyhilo.util import from_utc_timestamp

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 
 from homeassistant.components.integration.sensor import (
     LEFT_METHOD,
-    TRAPEZOIDAL_METHOD,
     IntegrationSensor,
 )
 from homeassistant.components.sensor import (


### PR DESCRIPTION
J'ai un peu fouillé dans le code et je crois avoir réussi à mettre la méthode d'intégration left pour les compteurs d'énergie au lieu de trapezoidal qui était là actuellement, pour régler les problèmes de compteurs individuels surestimés.

Pour ce qui est du unknown energy meter je crois que ca décale un peu car parfois le calcul est soit surestimé ou sous-estimé à cause des grandes variations du smart energy meter (à preuve ca tombe parfois dans le négatif). Bref j'ai trouvé un ajustement pour pouvoir faire en sorte que le compteur puisse redescendre quand c'est dans le négatif, ca devrait aider à être plus près de la vraie moyenne je crois.

Et en fouillant dans ces bouts de code je suis tombé sur les bouts utilisés pour les prochains événements et aussi les récompenses qui se retrouvaient parfois avec des arrays vides, j'ai donc ajouté une petite gestion pour garder l'état précédent si quelque chose se passe mal, je crois que c'est ce qui arrive présentement, genre il doit y avoir un timeout ou un blocage hilo qui embarque parfois... comme on vidait le array dès le début de l'update on restait alors avec vide jusqu'au prochain update réussi...

Bref ca roule de mon bord avec ces 4 petites modifs depuis hier et ca semble bien aller.