### PR TITLE
Fixes pour compteurs individuels et cache arrays

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         args:
           - --skip="./.*,*.json"
           - --quiet-level=4
-          - -L ba,hass
+          - -L ba,hass,que,bord
         exclude_types: [json]
   - repo: https://gitlab.com/pycqa/flake8
     rev: 4.0.1

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -249,7 +249,6 @@ class EnergySensor(IntegrationSensor):
         self._attr_name = f"hilo_energy_{slugify(device.name)}"
         self._unit_of_measurement = ENERGY_WATT_HOUR
         self._unit_prefix = None
-        self._net_consumption = True
         if device.type == "Meter":
             self._attr_name = HILO_ENERGY_TOTAL
             self._unit_of_measurement = ENERGY_KILO_WATT_HOUR
@@ -529,7 +528,6 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
                     events.append(Event(**details).as_dict())
                 season["events"] = events
                 new_history.append(season)
-            self._history = []
             self._history = new_history
 
 
@@ -609,13 +607,11 @@ class HiloChallengeSensor(HiloEntity, RestoreEntity, SensorEntity):
             if self._hilo.appreciation > 0:
                 event.appreciation(self._hilo.appreciation)
             new_events.append(event.as_dict())
+        self._state = "off"
+        self._next_events = []
         if len(new_events):
             self._state = new_events[0]["state"]
-            self._next_events = []
             self._next_events = new_events
-        else:
-            self._state = "off"
-            self._next_events = []
 
 
 class DeviceSensor(HiloEntity, SensorEntity):

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from homeassistant.components.integration.sensor import (
-    TRAPEZOIDAL_METHOD,
-    IntegrationSensor,
-)
+from homeassistant.components.integration.sensor import LEFT_METHOD, IntegrationSensor
 from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
     STATE_CLASS_TOTAL_INCREASING,
@@ -252,6 +249,7 @@ class EnergySensor(IntegrationSensor):
         self._attr_name = f"hilo_energy_{slugify(device.name)}"
         self._unit_of_measurement = ENERGY_WATT_HOUR
         self._unit_prefix = None
+        self._net_consumption = True
         if device.type == "Meter":
             self._attr_name = HILO_ENERGY_TOTAL
             self._unit_of_measurement = ENERGY_KILO_WATT_HOUR
@@ -268,7 +266,7 @@ class EnergySensor(IntegrationSensor):
             self._unit_prefix,
             "h",
             self._unit_of_measurement,
-            TRAPEZOIDAL_METHOD,
+            LEFT_METHOD,
         )
         self._state = 0
         self._last_period = 0
@@ -517,19 +515,22 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
             self._state = last_state.state
 
     async def _async_update(self):
-        self._history = []
         seasons = await self._hilo._api.get_seasons(self._hilo.devices.location_id)
-        for idx, season in enumerate(seasons):
-            if idx == 0:
-                self._state = season.get("totalReward", 0)
-            events = []
-            for raw_event in season.get("events", []):
-                details = await self._hilo._api.get_gd_events(
-                    self._hilo.devices.location_id, event_id=raw_event["id"]
-                )
-                events.append(Event(**details).as_dict())
-            season["events"] = events
-            self._history.append(season)
+        if seasons:
+            new_history = []
+            for idx, season in enumerate(seasons):
+                if idx == 0:
+                    self._state = season.get("totalReward", 0)
+                events = []
+                for raw_event in season.get("events", []):
+                    details = await self._hilo._api.get_gd_events(
+                        self._hilo.devices.location_id, event_id=raw_event["id"]
+                    )
+                    events.append(Event(**details).as_dict())
+                season["events"] = events
+                new_history.append(season)
+            self._history = []
+            self._history = new_history
 
 
 class HiloChallengeSensor(HiloEntity, RestoreEntity, SensorEntity):
@@ -597,7 +598,7 @@ class HiloChallengeSensor(HiloEntity, RestoreEntity, SensorEntity):
             self._next_events = last_state.attributes.get("next_events", [])
 
     async def _async_update(self):
-        self._next_events = []
+        new_events = []
         events = await self._hilo._api.get_gd_events(self._hilo.devices.location_id)
         LOG.debug(f"Events received from Hilo: {events}")
         for raw_event in events:
@@ -607,10 +608,14 @@ class HiloChallengeSensor(HiloEntity, RestoreEntity, SensorEntity):
             event = Event(**details)
             if self._hilo.appreciation > 0:
                 event.appreciation(self._hilo.appreciation)
-            self._next_events.append(event.as_dict())
-        self._state = "off"
-        if len(self._next_events):
-            self._state = self._next_events[0]["state"]
+            new_events.append(event.as_dict())
+        if len(new_events):
+            self._state = new_events[0]["state"]
+            self._next_events = []
+            self._next_events = new_events
+        else:
+            self._state = "off"
+            self._next_events = []
 
 
 class DeviceSensor(HiloEntity, SensorEntity):


### PR DESCRIPTION
J'ai un peu fouillé dans le code et je crois avoir réussi à mettre la méthode d'intégration left pour les compteurs d'énergie au lieu de trapezoidal qui était là actuellement, pour régler les problèmes de compteurs individuels surestimés.

Pour ce qui est du unknown energy meter je crois que ca décale un peu car parfois le calcul est soit surestimé ou sous-estimé à cause des grandes variations du smart energy meter (à preuve ca tombe parfois dans le négatif). Bref j'ai trouvé un ajustement pour pouvoir faire en sorte que le compteur puisse redescendre quand c'est dans le négatif, ca devrait aider à être plus près de la vraie moyenne je crois.

Et en fouillant dans ces bouts de code je suis tombé sur les bouts utilisés pour les prochains événements et aussi les récompenses qui se retrouvaient parfois avec des arrays vides, j'ai donc ajouté une petite gestion pour garder l'état précédent si quelque chose se passe mal, je crois que c'est ce qui arrive présentement, genre il doit y avoir un timeout ou un blocage hilo qui embarque parfois... comme on vidait le array dès le début de l'update on restait alors avec vide jusqu'au prochain update réussi...

Bref ca roule de mon bord avec ces 4 petites modifs depuis hier et ca semble bien aller.