### PR TITLE
Fix pour issue #221

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pythonenv*
 venv
 .venv
 .vscode
+.DS_Store

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -237,7 +237,7 @@ class EnergySensor(IntegrationSensor):
 
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_native_unit_of_measurement = ENERGY_WATT_HOUR
-    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_icon = "mdi:lightning-bolt"
 
     def __init__(self, device):


### PR DESCRIPTION
Scène 1, prise 2

Je suis sous OS X donc les .DS_Store sont des fichiers cachés de metadata créés automatiquement. Ajouté à .gitignore pour qu'on ne les voit plus passer.

Refait mon fix pour #221.

Merci pour le heads up pour le rebase je vais apprendre à jouer avec le CLI un peu.