### PR TITLE
retrait energy_manager.add_to_dashboard

### DIFF
--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -153,7 +153,6 @@ async def async_setup_entry(
             tariff_list = validate_tariff_list(tariff_config)
         net_consumption = device.net_consumption
         utility_manager.add_meter(energy_entity, tariff_list, net_consumption)
-        energy_manager.add_to_dashboard(energy_entity, tariff_list)
 
     for d in hilo.devices.all:
         LOG.debug(f"Adding device {d}")


### PR DESCRIPTION
Retiré energy_manager.add_to_dashboard, empêche l'ajout des sensors de puissance au dashboard energy sans en empêcher la création pour les sensors riemann sum.

Fix pour issue #205