### PR TITLE
Ajout du unique_id au sensor d'énergie

### DIFF
--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -243,7 +243,8 @@ class EnergySensor(IntegrationSensor):
 
     def __init__(self, device):
         self._device = device
-        self._attr_name = f"hilo_energy_{slugify(device.name)}"
+        self._attr_name = f"Hilo Energy {slugify(device.name)}"
+        self._attr_unique_id = f"hilo_energy_{slugify(device.name)}"
         self._unit_of_measurement = ENERGY_WATT_HOUR
         self._unit_prefix = None
         if device.type == "Meter":


### PR DESCRIPTION
Permettrait possiblement d'arranger #281

Comme ils n'avaient pas de uniqueid il n'arrivaient pas à se populer. Les autres sensors (température, power, etc.) avait leur unique id et étaient fonctionnels.


Merci de faire un release incluant une nouvelle version python-hilo pour inclure mon autre PR.