### PR TITLE
Ajout du unique_id aux sensors du rate et ajout des sensors dans le device du Gateway

### DIFF
--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -681,8 +681,8 @@ class HiloCostSensor(HiloEntity, RestoreEntity, SensorEntity):
         self.plan_name = plan_name
         self._amount = amount
         self._attr_unique_id = slugify(self._attr_name)
-        super().__init__(hilo, name=self._attr_name, device=device)
         self._last_update = dt_util.utcnow()
+        super().__init__(hilo, name=self._attr_name, device=device)
         LOG.info(f"Initializing energy cost sensor {name} {plan_name} Amount: {amount}")
 
     @property

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -173,7 +173,9 @@ async def async_setup_entry(
     for tarif, amount in tariff_config.items():
         if amount > 0:
             sensor_name = f"Hilo rate {tarif}"
-            cost_entities.append(HiloCostSensor(hilo, sensor_name, hq_plan_name, amount))
+            cost_entities.append(
+                HiloCostSensor(hilo, sensor_name, hq_plan_name, amount)
+            )
     cost_entities.append(HiloCostSensor(hilo, "Hilo rate current", hq_plan_name))
     async_add_entities(cost_entities)
     # This setups the utility_meter platform
@@ -704,7 +706,9 @@ class HiloCostSensor(HiloEntity, RestoreEntity, SensorEntity):
         if last_state:
             self._last_update = dt_util.utcnow()
             self._amount = last_state.state
-            LOG.info(f"Restoring energy cost sensor {last_state.name} {self.plan_name} Amount: {self._amount}")
+            LOG.info(
+                f"Restoring energy cost sensor {last_state.name} {self.plan_name} Amount: {self._amount}"
+            )
 
     async def async_update(self):
         return


### PR DESCRIPTION
Les rate sensor sont maintenant éditable et ajouté dans le device du gataway au lieu d'être orpheline.
J'ai aussi changé les unités pour le low_threshold comme ça il a les même unités que hilo_energy_total.