### PR TITLE
Fix potentiel pour energy sensors

### DIFF
--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CURRENCY_DOLLAR,
     ENERGY_KILO_WATT_HOUR,
-    ENERGY_WATT_HOUR,
     PERCENTAGE,
     POWER_WATT,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
@@ -93,22 +92,22 @@ def generate_entities_from_device(device, hilo, scan_interval):
         entities.append(
             HiloNotificationSensor(hilo, device, scan_interval),
         )
-    if device.has_attribute("current_temperature"):
-        entities.append(TemperatureSensor(hilo, device))
-    if device.has_attribute("target_temperature"):
-        entities.append(TargetTemperatureSensor(hilo, device))
-    if device.has_attribute("co2"):
-        entities.append(Co2Sensor(hilo, device))
-    if device.has_attribute("noise"):
-        entities.append(NoiseSensor(hilo, device))
-    if device.has_attribute("wifi_status"):
-        entities.append(WifiStrengthSensor(hilo, device))
     if device.has_attribute("battery"):
         entities.append(BatterySensor(hilo, device))
+    if device.has_attribute("co2"):
+        entities.append(Co2Sensor(hilo, device))
+    if device.has_attribute("current_temperature"):
+        entities.append(TemperatureSensor(hilo, device))
     if device.type in HILO_SENSOR_CLASSES:
         entities.append(DeviceSensor(hilo, device))
+    if device.has_attribute("noise"):
+        entities.append(NoiseSensor(hilo, device))
     if device.has_attribute("power"):
         entities.append(PowerSensor(hilo, device))
+    if device.has_attribute("target_temperature"):
+        entities.append(TargetTemperatureSensor(hilo, device))
+    if device.has_attribute("wifi_status"):
+        entities.append(WifiStrengthSensor(hilo, device))
     return entities
 
 
@@ -237,7 +236,7 @@ class EnergySensor(IntegrationSensor):
     """Define a Hilo energy sensor entity."""
 
     _attr_device_class = SensorDeviceClass.ENERGY
-    _attr_native_unit_of_measurement = ENERGY_WATT_HOUR
+    _attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_icon = "mdi:lightning-bolt"
 
@@ -245,7 +244,7 @@ class EnergySensor(IntegrationSensor):
         self._device = device
         self._attr_name = f"Hilo Energy {slugify(device.name)}"
         self._attr_unique_id = f"hilo_energy_{slugify(device.name)}"
-        self._unit_of_measurement = ENERGY_WATT_HOUR
+        self._unit_of_measurement = ENERGY_KILO_WATT_HOUR
         self._unit_prefix = None
         if device.type == "Meter":
             self._attr_name = HILO_ENERGY_TOTAL
@@ -279,8 +278,6 @@ class EnergySensor(IntegrationSensor):
         """Handle entity which will be added."""
         LOG.debug(f"Added to hass: {self._attr_name}")
         await super().async_added_to_hass()
-        if state := await self.async_get_last_state():
-            self._state = state.state
 
 
 class NoiseSensor(HiloEntity, SensorEntity):


### PR DESCRIPTION
Possible fix pour #121 #281 #283 #292

Réordonné la création des entités pour créer les power sensors plus tôt dans le boot pour aider les riemann sum.

Mis la bonne unité dans les energy sensors de base. Je ne voyais pas l'utilité de garder des Wh.

Retrait de async_get_last_state pour les energy sensors, causait des problèmes souvent au redémarrage. Amenait des state unavailable aussitôt qu'il y avait un petit rot chez Hilo ou un manque de données temporaire. Les sensors devenaient alors unavailable sans moyen de les ramener. Les riemann sum tombait donc indisponible et inutilisables.

@valleedelisle je pense avoir causé du dead code par la bande ligne 278. Code review si jamais tu as le temps?

Il pourrait être nécessaire de faire le bouton fix issue dans developper tools -> statistics pour régler les unités.