### PR TITLE
Support new SignalR commands, device types and misc fixes

### DIFF
--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -62,10 +62,10 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_TRACK_UNKNOWN_SOURCES,
     DEFAULT_UNTARIFICATED_DEVICES,
-    MIN_SCAN_INTERVAL,
     DOMAIN,
     HILO_ENERGY_TOTAL,
     LOG,
+    MIN_SCAN_INTERVAL,
 )
 
 DISPATCHER_TOPIC_WEBSOCKET_EVENT = "pyhilo_websocket_event"
@@ -127,7 +127,9 @@ async def async_setup_entry(  # noqa: C901
     current_options = {**entry.options}
     log_traces = current_options.get(CONF_LOG_TRACES, DEFAULT_LOG_TRACES)
     scan_interval = current_options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-    scan_interval = scan_interval if scan_interval >= MIN_SCAN_INTERVAL else MIN_SCAN_INTERVAL
+    scan_interval = (
+        scan_interval if scan_interval >= MIN_SCAN_INTERVAL else MIN_SCAN_INTERVAL
+    )
     state_yaml = hass.config.path(DEFAULT_STATE_FILE)
 
     websession = aiohttp_client.async_get_clientsession(hass)
@@ -213,9 +215,7 @@ class Hilo:
         self.devices: Devices = Devices(api)
         self._websocket_reconnect_task: asyncio.Task | None = None
         self._update_task: asyncio.Task | None = None
-        self.invocations = {
-            0: self.subscribe_to_location
-        }
+        self.invocations = {0: self.subscribe_to_location}
         self.hq_plan_name = entry.options.get(CONF_HQ_PLAN_NAME, DEFAULT_HQ_PLAN_NAME)
         self.appreciation = entry.options.get(
             CONF_APPRECIATION_PHASE, DEFAULT_APPRECIATION_PHASE
@@ -261,7 +261,9 @@ class Hilo:
                 for item in event.arguments[0]
             )
             if new_devices:
-                LOG.warn("Device list appears to be desynchronized, forcing a refresh thru the API...")
+                LOG.warn(
+                    "Device list appears to be desynchronized, forcing a refresh thru the API..."
+                )
                 await self.devices.update()
 
             updated_devices = self.devices.parse_values_received(event.arguments[0])
@@ -274,13 +276,17 @@ class Hilo:
         elif event.target == "DeviceListInitialValuesReceived":
             # This websocket event only happens after calling SubscribeToLocation.
             # This triggers an update without throwing an exception
-            new_devices = await self.devices.update_devicelist_from_signalr(event.arguments[0])
+            new_devices = await self.devices.update_devicelist_from_signalr(
+                event.arguments[0]
+            )
         elif event.target == "DeviceListUpdatedValuesReceived":
             # This message only contains display informations, such as the Device's name (as set in the app), it's groupid, icon, etc.
             # Updating the device name causes issues in the integration, it detects it as a new device and creates a new entity.
             # Ignore this call, for now... (update_devicelist_from_signalr does work, but causes the issue above)
             # await self.devices.update_devicelist_from_signalr(event.arguments[0])
-            LOG.debug("Received 'DeviceListUpdatedValuesReceived' message, not implemented yet.")
+            LOG.debug(
+                "Received 'DeviceListUpdatedValuesReceived' message, not implemented yet."
+            )
         elif event.target == "DevicesListChanged":
             # This message only contains the location_id and is used to inform us that devices have been removed from the location.
             # Device deletion is not implemented yet, so we just log the message for now.

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -305,7 +305,7 @@ class Hilo:
             gateway = self.devices.find_device(1)
             if gateway:
                 gateway.id = event.arguments[0][0]["deviceId"]
-                LOG.debug("Updated Gateway's deviceId from default 1 to {gateway.id}")
+                LOG.debug(f"Updated Gateway's deviceId from default 1 to {gateway.id}")
 
             updated_devices = self.devices.parse_values_received(event.arguments[0])
             # NOTE(dvd): If we don't do this, we need to wait until the coordinator

--- a/custom_components/hilo/const.py
+++ b/custom_components/hilo/const.py
@@ -35,7 +35,8 @@ DEFAULT_UNTARIFICATED_DEVICES = False
 DEFAULT_SCAN_INTERVAL = 300
 EVENT_SCAN_INTERVAL = 3000
 REWARD_SCAN_INTERVAL = 7200
-MIN_SCAN_INTERVAL = 15
+NOTIFICATION_SCAN_INTERVAL = 1800
+MIN_SCAN_INTERVAL = 60
 
 CONF_TARIFF = {
     "rate d": {
@@ -71,5 +72,5 @@ HILO_SENSOR_CLASSES = [
     "OutdoorWeatherStation",
     "Gateway",
 ]
-CLIMATE_CLASSES = ["Thermostat"]
-SWITCH_CLASSES = ["Outlet"]
+CLIMATE_CLASSES = ["Thermostat", "FloorThermostat", "Thermostat24V"]
+SWITCH_CLASSES = ["Outlet", "Ccr", "Cee"]

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -548,10 +548,10 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
             for idx, season in enumerate(seasons):
                 current_history_season = next(
                     (
-                        item 
-                        for item in current_history 
+                        item
+                        for item in current_history
                         if item.get("season") == season.get("season")
-                    ), 
+                    ),
                     None
                 )
 
@@ -565,17 +565,17 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
                     if current_history_season:
                         current_history_event = next(
                             (
-                                ev 
+                                ev
                                 for ev in current_history_season["events"] 
                                 if ev["event_id"] == raw_event["id"]
-                            ), 
+                            ),
                             None
                         )
 
                     start_date_utc = datetime.fromisoformat(raw_event["startDateUtc"])
                     event_age = datetime.now(timezone.utc) - start_date_utc
-                    if (current_history_event 
-                        and current_history_event.get("state") == "completed" 
+                    if (current_history_event
+                        and current_history_event.get("state") == "completed"
                         and event_age > timedelta(days=1)
                     ):
                         # No point updating events for previously completed events, they won't change.

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -1,7 +1,7 @@
 """Support for various Hilo sensors."""
 from __future__ import annotations
 
-from datetime import timedelta, datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from homeassistant.components.integration.sensor import METHOD_LEFT, IntegrationSensor
 from homeassistant.components.sensor import (
@@ -546,7 +546,14 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
             new_history = []
 
             for idx, season in enumerate(seasons):
-                current_history_season = next((item for item in current_history if item.get("season") == season.get("season")), None)
+                current_history_season = next(
+                    (
+                        item 
+                        for item in current_history 
+                        if item.get("season") == season.get("season")
+                    ), 
+                    None
+                )
 
                 if idx == 0:
                     self._state = season.get("totalReward", 0)
@@ -556,11 +563,21 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
                     event = None
 
                     if current_history_season:
-                        current_history_event = next((ev for ev in current_history_season["events"] if ev["event_id"] == raw_event["id"]), None)
+                        current_history_event = next(
+                            (
+                                ev 
+                                for ev in current_history_season["events"] 
+                                if ev["event_id"] == raw_event["id"]
+                            ), 
+                            None
+                        )
 
                     start_date_utc = datetime.fromisoformat(raw_event["startDateUtc"])
                     event_age = datetime.now(timezone.utc) - start_date_utc
-                    if current_history_event and current_history_event.get("state") == "completed" and event_age > timedelta(days=1):
+                    if (current_history_event 
+                        and current_history_event.get("state") == "completed" 
+                        and event_age > timedelta(days=1)
+                    ):
                         # No point updating events for previously completed events, they won't change.
                         event = current_history_event
                     else:

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -552,7 +552,7 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
                         for item in current_history
                         if item.get("season") == season.get("season")
                     ),
-                    None
+                    None,
                 )
 
                 if idx == 0:
@@ -566,15 +566,16 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
                         current_history_event = next(
                             (
                                 ev
-                                for ev in current_history_season["events"] 
+                                for ev in current_history_season["events"]
                                 if ev["event_id"] == raw_event["id"]
                             ),
-                            None
+                            None,
                         )
 
                     start_date_utc = datetime.fromisoformat(raw_event["startDateUtc"])
                     event_age = datetime.now(timezone.utc) - start_date_utc
-                    if (current_history_event
+                    if (
+                        current_history_event
                         and current_history_event.get("state") == "completed"
                         and event_age > timedelta(days=1)
                     ):


### PR DESCRIPTION
Support for new attribute without causing warnings
Support for CCR/CEE (as switches)
Partial Support for 24v thermostat (honeywell / resideo) (as a regular thermostat).. still work to be done 
Support for Floor thermostat (as a regular thermostat) 
Raise the Notification scan interval (only used for OneLink's messages: low battery, test alert, etc) 
Cleanup obsolete code (subscribe_to_attributes)
Implement some missing signalr commands... Still need to figure out how to create entities on the fly, outside of initialization 
No need to poll Getway anymore, values are received thru signalR "GatewayValuesReceived"