### PR TITLE
Change minimum scan_interval (60s) in the docs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -165,10 +165,10 @@ Other options are available under the `Configure` button in Home Assistant:
   - `rate d`
   - `flex d`
 
-- `scan_interval`: Integer
+- `Scan interval (min: 60s)`: Integer
 
   Number of seconds between each device update. Defaults to 60 and it's not recommended to go below 30 as it might
-  result in a suspension from Hilo.
+  result in a suspension from Hilo. Since [2023.11.1](https://github.com/dvd-dev/hilo/releases/tag/v2023.11.1) the mimnium has changed from 15s to 60s.
 
 ## Lovelace sample integration and automation example
 

--- a/README.en.md
+++ b/README.en.md
@@ -168,7 +168,7 @@ Other options are available under the `Configure` button in Home Assistant:
 - `Scan interval (min: 60s)`: Integer
 
   Number of seconds between each device update. Defaults to 60 and it's not recommended to go below 30 as it might
-  result in a suspension from Hilo. Since [2023.11.1](https://github.com/dvd-dev/hilo/releases/tag/v2023.11.1) the mimnium has changed from 15s to 60s.
+  result in a suspension from Hilo. Since [2023.11.1](https://github.com/dvd-dev/hilo/releases/tag/v2023.11.1) the minimum has changed from 15s to 60s.
 
 ## Lovelace sample integration and automation example
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ D'autres options sont disponibles sous le bouton "Configurer" dans Home Assistan
 
 - `Intervalle de mise à jour (min: 60s)`: Nombre entier
 
-  Nombre de secondes entre chaque mise à jour de l'appareil. Par défaut à 60s. Il n'est pas recommandé d'aller en dessous de 30 car cela pourrait entraîner une suspension de Hilo. Depuis [2023.11.1](https://github.com/dvd-dev/hilo/releases/tag/v2023.11.1) le mimnium est passé de 15s à 60s.
+  Nombre de secondes entre chaque mise à jour de l'appareil. Par défaut à 60s. Il n'est pas recommandé d'aller en dessous de 30 car cela pourrait entraîner une suspension de Hilo. Depuis [2023.11.1](https://github.com/dvd-dev/hilo/releases/tag/v2023.11.1) le minimum est passé de 15s à 60s.
 
 ## Exemples d'intégrations Lovelace et d'automatisations
 

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ D'autres options sont disponibles sous le bouton "Configurer" dans Home Assistan
   - 'rate d'
   - 'flex d'
 
-- `Intervalle de mise à jour (min: 15s)`: Nombre entier
+- `Intervalle de mise à jour (min: 60s)`: Nombre entier
 
-  Nombre de secondes entre chaque mise à jour de l'appareil. Par défaut à 60s. Il n'est pas recommandé d'aller en dessous de 30 car cela pourrait entraîner une suspension de Hilo.
+  Nombre de secondes entre chaque mise à jour de l'appareil. Par défaut à 60s. Il n'est pas recommandé d'aller en dessous de 30 car cela pourrait entraîner une suspension de Hilo. Depuis [2023.11.1](https://github.com/dvd-dev/hilo/releases/tag/v2023.11.1) le mimnium est passé de 15s à 60s.
 
 ## Exemples d'intégrations Lovelace et d'automatisations
 

--- a/custom_components/hilo/translations/en.json
+++ b/custom_components/hilo/translations/en.json
@@ -26,7 +26,7 @@
           "generate_energy_meters": "Generate energy meters",
           "untarificated_devices": "Generate only total meters for each devices",
           "hq_plan_name": "Hydro Quebec rate plan name ('rate d' or 'flex d')",
-          "scan_interval": "Scan interval (min: 15s)",
+          "scan_interval": "Scan interval (min: 60s)",
           "log_traces": "Also log request data and websocket messages (requires debug log level on both the integration and pyhilo)",
           "challenge_lock": "Lock climate entities during Hilo challenges, preventing any changes when a challenge is in progress.",
           "track_unknown_sources": "Track unknown power sources in a separate energy sensor. This is a round approximation calculated when we get a reading from the Smart Energy Meter.",

--- a/custom_components/hilo/translations/fr.json
+++ b/custom_components/hilo/translations/fr.json
@@ -26,7 +26,7 @@
           "generate_energy_meters": "Générer compteurs de consommation électrique",
           "untarificated_devices": "Générer seulement les compteurs totaux pour chaque appareil",
           "hq_plan_name": "Nom du tarif Hydro Québec ('rate d' ou 'flex d')",
-          "scan_interval": "Intervalle de mise à jour (min: 15s)",
+          "scan_interval": "Intervalle de mise à jour (min: 60s)",
           "log_traces": "Enregistrer aussi les requêtes et messages websocket (requiert le niveau de journalisation debug sur L'intégration et pyhilo)",
           "challenge_lock": "Vérouiller les entités climate lors de défis Hilo, empêchant tout changement lorsqu'un défi est en cours.",
           "track_unknown_sources": "Suivre des sources de consommation inconnues dans un compteur séparé. Ceci est une approximation calculée à partir de la lecture du compteur intelligent.",


### PR DESCRIPTION
Modification de la doc depuis les changement de 2023.11.1 dans `const.py` et `__init__.py` pour le minimum du `scan_interval` par [nlz242](https://github.com/nlz242/hilo/commits?author=nlz242)