### PR TITLE
Retrait  last state cost sensor

### DIFF
--- a/custom_components/hilo/manifest.json
+++ b/custom_components/hilo/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dvd-dev/hilo/issues",
   "requirements": ["python-hilo>=2023.11.1"],
-  "version": "2023.11.1"
+  "version": "2023.11.2"
 }

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -739,13 +739,6 @@ class HiloCostSensor(HiloEntity, RestoreEntity, SensorEntity):
     async def async_added_to_hass(self):
         """Handle entity about to be added to hass event."""
         await super().async_added_to_hass()
-        last_state = await self.async_get_last_state()
-        if last_state:
-            self._last_update = dt_util.utcnow()
-            self._amount = last_state.state
-            LOG.info(
-                f"Restoring energy cost sensor {last_state.name} {self.plan_name} Amount: {self._amount}"
-            )
 
     async def async_update(self):
         return


### PR DESCRIPTION
Causait les mêmes problèmes aux cost sensors que #308

Au redémarrage les sensors devenaient unavailable.

Fix pour dvd-dev/hilo#321