### PR TITLE
Change authentication flow from ROPC to authorization code with PKCE

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -81,8 +81,7 @@ If the component is properly installed, you should be able to find the 'Hilo int
 
 ## Configuration
 
-The configuration is done in the UI. When you add the integration, you will be prompted with your
-Hilo username and password. After this, you will be prompted with assigning a room for each one of
+The configuration is done in the UI. When you add the integration, you will be redirect to Hilo's authentication website. You have to accept to link your account. After this, you will be prompted with assigning a room for each one of
 your devices.
 
 ### Energy meters

--- a/README.en.md
+++ b/README.en.md
@@ -81,7 +81,7 @@ If the component is properly installed, you should be able to find the 'Hilo int
 
 ## Configuration
 
-The configuration is done in the UI. When you add the integration, you will be redirect to Hilo's authentication website. You have to accept to link your account. After this, you will be prompted with assigning a room for each one of
+The configuration is done in the UI. When you add the integration, you will be redirected to Hilo's authentication website. You have to accept to link your account. After this, you will be prompted with assigning a room for each one of
 your devices.
 
 ### Energy meters

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Si l'intégration est correctement installée, vous devriez pouvoir trouver "Hil
 
 ## Configuration
 
-La configuration est faite via l'interface utilisateur. Lorsque vous ajoutez l'intégration, votre nom d'utilisateur et mot de passe Hio vous seront demandés. Après, vous devrez assigner une pièce de votre maison à chaque appareil.
+La configuration est faite via l'interface utilisateur. Lorsque vous ajoutez l'intégration, vous êtes redirigés vers le site de connexion d'Hilo afin de vous y authentifier. Vous devez ensuite accepter de lier votre compte. Après, vous devrez assigner une pièce de votre maison à chaque appareil.
 
 
 ### :warning: Compteurs de consommation électrique

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -191,6 +191,26 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
+async def async_migrate_entry(hass, config_entry: ConfigEntry):
+    """Migrate old entry."""
+    LOG.debug("Migrating from version %s", config_entry.version)
+
+    if config_entry.version > 1:
+      # This means the user has downgraded from a future version
+        return False
+
+    if config_entry.version == 1:
+        config_entry.version = 2
+        hass.config_entries.async_update_entry(
+            config_entry, unique_id="hilo",
+            title="Hilo",
+            data={"auth_implementation" : "hilo"}
+        )
+
+    LOG.debug("Migration to version %s successful", config_entry.version)
+
+    return True
+
 class Hilo:
     """Define a Hilo data object."""
 

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -203,7 +203,6 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         config_entry.version = 2
         hass.config_entries.async_update_entry(
             config_entry, unique_id="hilo",
-            title="Hilo",
             data={"auth_implementation" : "hilo"}
         )
 

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -23,8 +23,8 @@ from homeassistant.const import (
 from homeassistant.core import Context, Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import (
-    aiohttp_client, 
-    config_entry_oauth2_flow, 
+    aiohttp_client,
+    config_entry_oauth2_flow,
     device_registry as dr,
 )
 from homeassistant.helpers.dispatcher import (
@@ -145,7 +145,7 @@ async def async_setup_entry(  # noqa: C901
             oauth_session=config_entry_oauth2_flow.OAuth2Session(
                 hass, entry, implementation
             ),
-            log_traces=current_options.get(CONF_LOG_TRACES, DEFAULT_LOG_TRACES)
+            log_traces=current_options.get(CONF_LOG_TRACES, DEFAULT_LOG_TRACES),
         )
     except Exception as err:
         raise ConfigEntryAuthFailed(err) from err
@@ -210,7 +210,7 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
     if config_entry.version == 1:
         config_entry.version = 2
         hass.config_entries.async_update_entry(
-            config_entry, unique_id="hilo", data={"auth_implementation" : "hilo"}
+            config_entry, unique_id="hilo", data={"auth_implementation": "hilo"}
         )
 
     LOG.debug("Migration to version %s successful", config_entry.version)

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -133,14 +133,13 @@ async def async_setup_entry(  # noqa: C901
 
     current_options = {**entry.options}
 
-    api = await API.async_create(
-        session=aiohttp_client.async_get_clientsession(hass),
-        oauth_session=config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation),
-        log_traces=current_options.get(CONF_LOG_TRACES, DEFAULT_LOG_TRACES)
-    )
     try:
-        await api.async_get_access_token()
-    except Exception as err:
+        api = await API.async_create(
+            session=aiohttp_client.async_get_clientsession(hass),
+            oauth_session=config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation),
+            log_traces=current_options.get(CONF_LOG_TRACES, DEFAULT_LOG_TRACES)
+        )
+    except Exception as err:        
         raise ConfigEntryAuthFailed(err) from err
 
     _async_standardize_config_entry(hass, entry)

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -22,7 +22,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context, Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow, device_registry as dr
+from homeassistant.helpers import (
+    aiohttp_client, 
+    config_entry_oauth2_flow, 
+    device_registry as dr,
+)
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
@@ -41,7 +45,7 @@ from pyhilo.exceptions import HiloError, InvalidCredentialsError, WebsocketError
 from pyhilo.util import from_utc_timestamp, time_diff
 from pyhilo.websocket import WebsocketEvent
 
-from .config_flow import HiloFlowHandler, STEP_OPTION_SCHEMA
+from .config_flow import STEP_OPTION_SCHEMA, HiloFlowHandler
 from .const import (
     CONF_APPRECIATION_PHASE,
     CONF_CHALLENGE_LOCK,
@@ -123,7 +127,9 @@ async def async_setup_entry(  # noqa: C901
     hass: HomeAssistant, entry: ConfigEntry
 ) -> bool:
     """Set up Hilo as config entry."""
-    HiloFlowHandler.async_register_implementation(hass, AuthCodeWithPKCEImplementation(hass))
+    HiloFlowHandler.async_register_implementation(
+        hass, AuthCodeWithPKCEImplementation(hass)
+    )
 
     implementation = (
         await config_entry_oauth2_flow.async_get_config_entry_implementation(
@@ -136,10 +142,12 @@ async def async_setup_entry(  # noqa: C901
     try:
         api = await API.async_create(
             session=aiohttp_client.async_get_clientsession(hass),
-            oauth_session=config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation),
+            oauth_session=config_entry_oauth2_flow.OAuth2Session(
+                hass, entry, implementation
+            ),
             log_traces=current_options.get(CONF_LOG_TRACES, DEFAULT_LOG_TRACES)
         )
-    except Exception as err:        
+    except Exception as err:
         raise ConfigEntryAuthFailed(err) from err
 
     _async_standardize_config_entry(hass, entry)
@@ -196,19 +204,19 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
     LOG.debug("Migrating from version %s", config_entry.version)
 
     if config_entry.version > 1:
-      # This means the user has downgraded from a future version
+        # This means the user has downgraded from a future version
         return False
 
     if config_entry.version == 1:
         config_entry.version = 2
         hass.config_entries.async_update_entry(
-            config_entry, unique_id="hilo",
-            data={"auth_implementation" : "hilo"}
+            config_entry, unique_id="hilo", data={"auth_implementation" : "hilo"}
         )
 
     LOG.debug("Migration to version %s successful", config_entry.version)
 
     return True
+
 
 class Hilo:
     """Define a Hilo data object."""

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -34,7 +34,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 from pyhilo import API
-from pyhilo.auth.oauth2 import OAuth2Impl
+from pyhilo.auth.oauth2 import AuthCodeWithPKCEImplementation
 from pyhilo.device import HiloDevice
 from pyhilo.devices import Devices
 from pyhilo.exceptions import HiloError, InvalidCredentialsError, WebsocketError
@@ -123,7 +123,7 @@ async def async_setup_entry(  # noqa: C901
     hass: HomeAssistant, entry: ConfigEntry
 ) -> bool:
     """Set up Hilo as config entry."""
-    HiloFlowHandler.async_register_implementation(hass, OAuth2Impl(hass))
+    HiloFlowHandler.async_register_implementation(hass, AuthCodeWithPKCEImplementation(hass))
 
     implementation = (
         await config_entry_oauth2_flow.async_get_config_entry_implementation(

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -38,10 +38,10 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 from pyhilo import API
-from pyhilo.oauth2 import AuthCodeWithPKCEImplementation
 from pyhilo.device import HiloDevice
 from pyhilo.devices import Devices
 from pyhilo.exceptions import HiloError, InvalidCredentialsError, WebsocketError
+from pyhilo.oauth2 import AuthCodeWithPKCEImplementation
 from pyhilo.util import from_utc_timestamp, time_diff
 from pyhilo.websocket import WebsocketEvent
 

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -38,7 +38,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 from pyhilo import API
-from pyhilo.auth.oauth2 import AuthCodeWithPKCEImplementation
+from pyhilo.oauth2 import AuthCodeWithPKCEImplementation
 from pyhilo.device import HiloDevice
 from pyhilo.devices import Devices
 from pyhilo.exceptions import HiloError, InvalidCredentialsError, WebsocketError

--- a/custom_components/hilo/config_flow.py
+++ b/custom_components/hilo/config_flow.py
@@ -82,6 +82,7 @@ class HiloFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
     """Handle a Hilo config flow."""
 
     DOMAIN = DOMAIN
+    VERSION = 2
 
     _reauth_entry: ConfigEntry | None = None
 

--- a/custom_components/hilo/config_flow.py
+++ b/custom_components/hilo/config_flow.py
@@ -110,7 +110,7 @@ class HiloFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> HiloOptionsFlowHandler:
-        """Define the config flow to handle options."""        
+        """Define the config flow to handle options."""
         return HiloOptionsFlowHandler(config_entry)
 
     async def async_step_reauth(self, user_input=None) -> FlowResult:

--- a/custom_components/hilo/config_flow.py
+++ b/custom_components/hilo/config_flow.py
@@ -1,6 +1,8 @@
 """Config flow to configure the Hilo component."""
 from __future__ import annotations
 
+import jwt
+
 import logging
 
 from typing import Any
@@ -137,8 +139,14 @@ class HiloFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
             self.hass.config_entries.async_update_entry(self._reauth_entry, data=data)
             await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
             return self.async_abort(reason="reauth_successful")
+
         LOG.debug("Creating entry: %s", data)
-        return await super().async_oauth_create_entry(data)
+
+        token = data["token"]["access_token"]
+        decoded_token = jwt.decode(token, options={"verify_signature": False})
+        email = decoded_token["email"]
+
+        return self.async_create_entry(title=email, data=data)
 
 class HiloOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a Hilo options flow."""

--- a/custom_components/hilo/config_flow.py
+++ b/custom_components/hilo/config_flow.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-
 from typing import Any
 
 from homeassistant import config_entries
@@ -143,6 +142,7 @@ class HiloFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
         email = decoded_token["email"]
 
         return self.async_create_entry(title=email, data=data)
+
 
 class HiloOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a Hilo options flow."""

--- a/custom_components/hilo/config_flow.py
+++ b/custom_components/hilo/config_flow.py
@@ -1,24 +1,19 @@
 """Config flow to configure the Hilo component."""
 from __future__ import annotations
 
-import jwt
-
 import logging
 
 from typing import Any
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_SCAN_INTERVAL,
-)
+from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.config_entry_oauth2_flow import AbstractOAuth2FlowHandler
-
+import jwt
 from pyhilo.auth.oauth2 import AuthCodeWithPKCEImplementation
-
 import voluptuous as vol
 
 from .const import (
@@ -79,6 +74,7 @@ STEP_OPTION_SCHEMA = vol.Schema(
         ),
     }
 )
+
 
 class HiloFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
     """Handle a Hilo config flow."""

--- a/custom_components/hilo/config_flow.py
+++ b/custom_components/hilo/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.config_entry_oauth2_flow import AbstractOAuth2FlowHandler
 import jwt
-from pyhilo.auth.oauth2 import AuthCodeWithPKCEImplementation
+from pyhilo.oauth2 import AuthCodeWithPKCEImplementation
 import voluptuous as vol
 
 from .const import (

--- a/custom_components/hilo/manifest.json
+++ b/custom_components/hilo/manifest.json
@@ -11,6 +11,6 @@
   "documentation": "https://github.com/dvd-dev/hilo",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dvd-dev/hilo/issues",
-  "requirements": ["python-hilo>=2023.12.1"],
-  "version": "2023.12.2"
+  "requirements": ["python-hilo>=2023.12.2"],
+  "version": "2023.12.3"
 }

--- a/custom_components/hilo/translations/en.json
+++ b/custom_components/hilo/translations/en.json
@@ -18,7 +18,7 @@
       "already_configured": "This Hilo account is already in use.",
       "reauth_successful": "Re-authentication was successful",
       "user_rejected_authorize" : "Account linking rejected",
-      "single_instance_allowed" : "Already configured. Only a single configuration possible."
+      "single_instance_allowed" : "Already configured. Only a single configuration is possible."
     }
   },
   "options": {

--- a/custom_components/hilo/translations/en.json
+++ b/custom_components/hilo/translations/en.json
@@ -2,11 +2,11 @@
   "config": {
     "step": {
       "user": {
-        "description": "The Hilo integration interacts with the Hilo application. Hilo is a smart home product made by a subsidary of Hydro Quebec.",
-        "data": {
-          "username": "Hilo Username",
-          "password": "Hilo Password"
-        }
+        "description": "The Hilo integration interacts with the Hilo application. Hilo is a smart home product made by a subsidary of Hydro Quebec."
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate integration",
+        "description": "The Hilo integration needs to re-authenticate your account"
       }
     },
     "error": {
@@ -15,7 +15,10 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "This Hilo account is already in use."
+      "already_configured": "This Hilo account is already in use.",
+      "reauth_successful": "Re-authentication was successful",
+      "user_rejected_authorize" : "Account linking rejected",
+      "single_instance_allowed" : "Already configured. Only a single configuration possible."
     }
   },
   "options": {

--- a/custom_components/hilo/translations/fr.json
+++ b/custom_components/hilo/translations/fr.json
@@ -7,7 +7,7 @@
       "reauth_confirm": {
         "title": "Réauthentifier l'intégration",
         "description": "L'intégration Hilo doit réauthentifier votre compte"
-      }    
+      }
     },
     "error": {
       "identifier_exists": "Compte déjà enregistré",

--- a/custom_components/hilo/translations/fr.json
+++ b/custom_components/hilo/translations/fr.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "L'intégration Hilo intéragit avec l'application Hilo. Hilo est un produit de domotique fait par une filliale de Hydro Québec."        
+        "description": "L'intégration Hilo intéragit avec l'application Hilo. Hilo est un produit de domotique fait par une filliale de Hydro Québec."
       },
       "reauth_confirm": {
         "title": "Réauthentifier l'intégration",

--- a/custom_components/hilo/translations/fr.json
+++ b/custom_components/hilo/translations/fr.json
@@ -2,12 +2,12 @@
   "config": {
     "step": {
       "user": {
-        "description": "L'intégration Hilo intéragit avec l'application Hilo. Hilo est un produit de domotique fait par une filliale de Hydro Québec.",
-        "data": {
-          "username": "Nom d'utilisateur Hilo",
-          "password": "Mot de passe Hilo"
-        }
-      }
+        "description": "L'intégration Hilo intéragit avec l'application Hilo. Hilo est un produit de domotique fait par une filliale de Hydro Québec."        
+      },
+      "reauth_confirm": {
+        "title": "Réauthentifier l'intégration",
+        "description": "L'intégration Hilo doit réauthentifier votre compte"
+      }    
     },
     "error": {
       "identifier_exists": "Compte déjà enregistré",
@@ -15,7 +15,10 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "Ce compte Hilo est déjà utilisé."
+      "already_configured": "Ce compte Hilo est déjà utilisé.",
+      "reauth_successful": "Réauthentifié avec succès",
+      "user_rejected_authorize" : "Association du compte refusée",
+      "single_instance_allowed" : "Déjà configurée. Une seule configuration possible."
     }
   },
   "options": {

--- a/info.md
+++ b/info.md
@@ -43,7 +43,7 @@ developers.
 
 ## Configuration
 
-The configuration is done in the UI. When you add the integration, you will be redirect to Hilo's authentication website.
+The configuration is done in the UI. When you add the integration, you will be redirected to Hilo's authentication website.
 You have to accept to link your account. After this, you will be prompted with assigning a room for each one of
 your devices.
 

--- a/info.md
+++ b/info.md
@@ -43,8 +43,8 @@ developers.
 
 ## Configuration
 
-The configuration is done in the UI. When you add the integration, you will be prompted with your
-Hilo username and password. After this, you will be prompted with assigning a room for each one of
+The configuration is done in the UI. When you add the integration, you will be redirect to Hilo's authentication website.
+You have to accept to link your account. After this, you will be prompted with assigning a room for each one of
 your devices.
 
 ### Energy meters


### PR DESCRIPTION
As part of the migration process from config VERSION 1 to VERSION 2, users will see a notification stating that an integration requires reconfiguration. By clicking "Reconfigure", the user will be redirected to Hilo's authentication website. After account linking, everything will work as usual.

A reauthentication process will also happen if access and refresh tokens are both expired.