### PR TITLE
Add text to reconfigure form

### DIFF
--- a/custom_components/hilo/translations/en.json
+++ b/custom_components/hilo/translations/en.json
@@ -7,6 +7,14 @@
           "username": "Hilo Username",
           "password": "Hilo Password"
         }
+      },
+      "reauth_confirm": {
+        "title": "Credentials",
+        "description": "The integration needs to re-authenticate your account",
+        "data": {
+          "username": "Hilo Username",
+          "password": "Hilo Password"
+        }
       }
     },
     "error": {
@@ -15,7 +23,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "This Hilo account is already in use."
+      "already_configured": "This Hilo account is already in use.",
+      "reauth_successful": "Re-authentication successful"
     }
   },
   "options": {

--- a/custom_components/hilo/translations/fr.json
+++ b/custom_components/hilo/translations/fr.json
@@ -7,6 +7,14 @@
           "username": "Nom d'utilisateur Hilo",
           "password": "Mot de passe Hilo"
         }
+      },
+      "reauth_confirm": {
+        "title": "Identifiants",
+        "description": "L'intégration doit ré-authentifier votre compte",
+        "data": {
+          "username": "Nom d'utilisateur Hilo",
+          "password": "Mot de passe Hilo"
+        }
       }
     },
     "error": {
@@ -15,7 +23,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "Ce compte Hilo est déjà utilisé."
+      "already_configured": "Ce compte Hilo est déjà utilisé.",
+      "reauth_successful": "Ré-authentification réussie"
     }
   },
   "options": {


### PR DESCRIPTION
Le form pour reconfigurer l'authentification était vide:
![reconfigure](https://github.com/dvd-dev/hilo/assets/44422604/52fe1271-b3d9-46a7-bbe4-369b84bad473)

J'ai donc ajouté les champs requis dans les 2 fichiers de traduction:
![Capture d’écran, le 2024-01-08 à 18 49 09](https://github.com/dvd-dev/hilo/assets/44422604/8578fa45-1fca-4806-80d8-5879944bfc6e)

J'ai aussi ajouté le champ pour le reauth_successful (Le form juste après l'authentification.