### PR TITLE
Invalidation du cache intelligente

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
 
 jobs:
   labeler:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - master
 jobs:
   draft_release:
     name: Release Drafter

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
       - dev
   pull_request:
   schedule:

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -373,13 +373,13 @@ class Hilo:
             if (
                 event.state == "reduction"
                 and event.last_update
-                <= datetime.now(timezone.utc).astimezone() - timedelta(seconds=EVENT_SCAN_INTERVAL_REDUCTION)
+                <= datetime.now(self.preheat_start.tzinfo) - timedelta(seconds=EVENT_SCAN_INTERVAL_REDUCTION)
             ):
                 LOG.debug(
                     f"Invalidating cache for event {event_id} during reduction phase ({event.last_update=})"
                 )
                 del self._events[event_id]
-            if event.last_update <= datetime.now(timezone.utc).astimezone() - timedelta(
+            if event.last_update <= datetime.now(self.preheat_start.tzinfo) - timedelta(
                 seconds=EVENT_SCAN_INTERVAL
             ):
                 LOG.debug(

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Union
 
 from homeassistant.components.select import (
@@ -66,8 +66,6 @@ from .const import (
     DEFAULT_TRACK_UNKNOWN_SOURCES,
     DEFAULT_UNTARIFICATED_DEVICES,
     DOMAIN,
-    EVENT_SCAN_INTERVAL,
-    EVENT_SCAN_INTERVAL_REDUCTION,
     HILO_ENERGY_TOTAL,
     LOG,
     MIN_SCAN_INTERVAL,
@@ -370,20 +368,16 @@ class Hilo:
                     f"Invalidating cache for event {event_id} during {event.state} phase ({event.current_phase_times=} {event.last_update=})"
                 )
                 del self._events[event_id]
-            if (
-                event.state == "reduction"
-                and event.last_update
-                <= datetime.now(timezone.utc).astimezone() - timedelta(seconds=EVENT_SCAN_INTERVAL_REDUCTION)
-            ):
+            """
+            Note ic-dev21: temp fix until we an make it prettier.
+            During reduction we delete the event attributes and reload
+            them with the next if, the rest of time time we're reading
+            it from cache
+            """
+
+            if event.state == "reduction":
                 LOG.debug(
                     f"Invalidating cache for event {event_id} during reduction phase ({event.last_update=})"
-                )
-                del self._events[event_id]
-            if event.last_update <= datetime.now(timezone.utc).astimezone() - timedelta(
-                seconds=EVENT_SCAN_INTERVAL
-            ):
-                LOG.debug(
-                    f"Invalidating cache for event {event_id} ({event.last_update=}): Older then {EVENT_SCAN_INTERVAL=}"
                 )
                 del self._events[event_id]
 

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -39,6 +39,7 @@ from pyhilo import API
 from pyhilo.const import DEFAULT_STATE_FILE
 from pyhilo.device import HiloDevice
 from pyhilo.devices import Devices
+from pyhilo.event import Event
 from pyhilo.exceptions import HiloError, InvalidCredentialsError, WebsocketError
 from pyhilo.util import from_utc_timestamp, time_diff
 from pyhilo.websocket import WebsocketEvent
@@ -362,7 +363,8 @@ class Hilo:
         the preheat_start, we refresh. This should update the
         allowed_kWh, etc values.
         """
-        if event := self._events.get(event_id):
+        if event_data := self._events.get(event_id):
+            event = Event(**event_data)
             if event.invalid:
                 LOG.debug(
                     f"Invalidating cache for event {event_id} during {event.state} phase ({event.current_phase_times=} {event.last_update=})"

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -354,6 +354,15 @@ class Hilo:
         }
 
     async def get_event_details(self, event_id: int):
+        """Getting events from Hilo only when necessary.
+        Otherwise, we hit the cache.
+        When preheat is started and our last update is before
+        the preheat_start, we refresh. This should update the
+        allowed_kWh, etc values.
+        """
+        if event := self._events.get(event_id):
+            if event.state == "pre_heat" and event.last_update <= event.preheat_start:
+                del self._events[event_id]
         if event_id not in self._events:
             self._events[event_id] = await self._api.get_gd_events(
                 self.devices.location_id, event_id=event_id

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -373,13 +373,13 @@ class Hilo:
             if (
                 event.state == "reduction"
                 and event.last_update
-                <= datetime.now(self.preheat_start.tzinfo) - timedelta(seconds=EVENT_SCAN_INTERVAL_REDUCTION)
+                <= datetime.now(timezone.utc).astimezone() - timedelta(seconds=EVENT_SCAN_INTERVAL_REDUCTION)
             ):
                 LOG.debug(
                     f"Invalidating cache for event {event_id} during reduction phase ({event.last_update=})"
                 )
                 del self._events[event_id]
-            if event.last_update <= datetime.now(self.preheat_start.tzinfo) - timedelta(
+            if event.last_update <= datetime.now(timezone.utc).astimezone() - timedelta(
                 seconds=EVENT_SCAN_INTERVAL
             ):
                 LOG.debug(

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Union
 
 from homeassistant.components.select import (
@@ -373,13 +373,13 @@ class Hilo:
             if (
                 event.state == "reduction"
                 and event.last_update
-                <= datetime.now() - timedelta(seconds=EVENT_SCAN_INTERVAL_REDUCTION)
+                <= datetime.now(timezone.utc).astimezone() - timedelta(seconds=EVENT_SCAN_INTERVAL_REDUCTION)
             ):
                 LOG.debug(
                     f"Invalidating cache for event {event_id} during reduction phase ({event.last_update=})"
                 )
                 del self._events[event_id]
-            if event.last_update <= datetime.now() - timedelta(
+            if event.last_update <= datetime.now(timezone.utc).astimezone() - timedelta(
                 seconds=EVENT_SCAN_INTERVAL
             ):
                 LOG.debug(

--- a/custom_components/hilo/const.py
+++ b/custom_components/hilo/const.py
@@ -39,6 +39,7 @@ DEFAULT_SCAN_INTERVAL = 300
 EVENT_SCAN_INTERVAL = 1800
 # During reduction phase, let's refresh the current challenge event
 # more often to get the reward numbers
+# Note ic-dev21: we'll stay at 300 until proper fix
 EVENT_SCAN_INTERVAL_REDUCTION = 300
 NOTIFICATION_SCAN_INTERVAL = 1800
 MIN_SCAN_INTERVAL = 60

--- a/custom_components/hilo/const.py
+++ b/custom_components/hilo/const.py
@@ -37,6 +37,9 @@ DEFAULT_UNTARIFICATED_DEVICES = False
 
 DEFAULT_SCAN_INTERVAL = 300
 EVENT_SCAN_INTERVAL = 1800
+# During reduction phase, let's refresh the current challenge event
+# more often to get the reward numbers
+EVENT_SCAN_INTERVAL_REDUCTION = 300
 NOTIFICATION_SCAN_INTERVAL = 1800
 MIN_SCAN_INTERVAL = 60
 REWARD_SCAN_INTERVAL = 7200

--- a/custom_components/hilo/manifest.json
+++ b/custom_components/hilo/manifest.json
@@ -11,6 +11,6 @@
   "documentation": "https://github.com/dvd-dev/hilo",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dvd-dev/hilo/issues",
-  "requirements": ["python-hilo>=2024.1.1"],
-  "version": "2024.2.1"
+  "requirements": ["python-hilo>=2024.1.2"],
+  "version": "2024.1.3"
 }

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -43,7 +43,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_UNTARIFICATED_DEVICES,
     DOMAIN,
-    EVENT_SCAN_INTERVAL,
+    EVENT_SCAN_INTERVAL_REDUCTION,
     HILO_ENERGY_TOTAL,
     HILO_SENSOR_CLASSES,
     LOG,
@@ -607,7 +607,8 @@ class HiloChallengeSensor(HiloEntity, RestoreEntity, SensorEntity):
         super().__init__(hilo, name=self._attr_name, device=device)
         self._attr_unique_id = slugify(self._attr_name)
         LOG.debug(f"Setting up ChallengeSensor entity: {self._attr_name}")
-        self.scan_interval = timedelta(seconds=EVENT_SCAN_INTERVAL)
+        # note ic-dev21: scan time at 5 minutes (300s) will force local update
+        self.scan_interval = timedelta(seconds=EVENT_SCAN_INTERVAL_REDUCTION)
         self._state = "off"
         self._next_events = []
         self.async_update = Throttle(self.scan_interval)(self._async_update)


### PR DESCRIPTION
Si un defi est en mode pre_heat, et que les metadata du defi datent d'avant le debut du pre_heat, on doit invalider le cache pour aller chercher les nouvelles donnees populees par Hilo.

Depends on dvd-dev/python-hilo#165