### PR TITLE
HiloRewardSensor unrecorded_attributes

### DIFF
--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -500,6 +500,7 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.MONETARY
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_suggested_unit_of_measurement = "CAD"
+    _entity_component_unrecorded_attributes = frozenset({"history"})
 
     def __init__(self, hilo, device, scan_interval):
         self._attr_name = "Recompenses Hilo"


### PR DESCRIPTION
Corriger l'erreur ci dessous pour sensor.recompenses_hilo
![image](https://github.com/dvd-dev/hilo/assets/44422604/8f2ab3e0-7a0c-43d5-b12c-b2c34f4821f9)
