### PR TITLE
Migrate unique to create real unique IDs

### DIFF
--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -712,6 +712,10 @@ class HiloEntity(CoordinatorEntity):
             }
         except AttributeError:
             pass
+        try:
+            self._attr_device_info["sw_version"] = device.sw_version
+        except AttributeError:
+            pass
         if not name:
             name = device.name
         self._attr_name = name

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.components.select import (
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    ATTR_CONNECTIONS,
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_PASSWORD,
@@ -704,6 +705,13 @@ class HiloEntity(CoordinatorEntity):
             name=device.name,
             via_device=(DOMAIN, gateway),
         )
+        try:
+            mac_address = dr.format_mac(device.sdi)
+            self._attr_device_info[ATTR_CONNECTIONS] = {
+                (dr.CONNECTION_NETWORK_MAC, mac_address)
+            }
+        except AttributeError:
+            pass
         if not name:
             name = device.name
         self._attr_name = name

--- a/custom_components/hilo/climate.py
+++ b/custom_components/hilo/climate.py
@@ -7,7 +7,12 @@ from homeassistant.components.climate.const import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_TENTHS, UnitOfTemperature
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    Platform,
+    PRECISION_TENTHS,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify
@@ -56,7 +61,11 @@ class HiloClimate(HiloEntity, ClimateEntity):
 
     def __init__(self, hilo: Hilo, device):
         super().__init__(hilo, device=device, name=device.name)
-        self._attr_unique_id = f"{slugify(device.name)}-climate"
+        old_unique_id = f"{slugify(device.name)}-climate"
+        self._attr_unique_id = f"{slugify(device.identifier)}-climate"
+        hilo.async_migrate_unique_id(
+            old_unique_id, self._attr_unique_id, Platform.CLIMATE
+        )
         self.operations = [HVACMode.HEAT]
         self._has_operation = False
         self._temperature_entity = None

--- a/custom_components/hilo/climate.py
+++ b/custom_components/hilo/climate.py
@@ -9,8 +9,8 @@ from homeassistant.components.climate.const import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_TEMPERATURE,
-    Platform,
     PRECISION_TENTHS,
+    Platform,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant

--- a/custom_components/hilo/light.py
+++ b/custom_components/hilo/light.py
@@ -5,6 +5,7 @@ from homeassistant.components.light import (
     LightEntity,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -30,7 +31,11 @@ async def async_setup_entry(
 class HiloLight(HiloEntity, LightEntity):
     def __init__(self, hass: HomeAssistant, hilo: Hilo, device):
         super().__init__(hilo, device=device, name=device.name)
-        self._attr_unique_id = f"{slugify(device.name)}-light"
+        old_unique_id = f"{slugify(device.name)}-light"
+        self._attr_unique_id = f"{slugify(device.identifier)}-light"
+        hilo.async_migrate_unique_id(
+            old_unique_id, self._attr_unique_id, Platform.LIGHT
+        )
         self._debounced_turn_on = Debouncer(
             hass,
             LOG,

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -195,7 +195,11 @@ class BatterySensor(HiloEntity, SensorEntity):
     def __init__(self, hilo, device):
         self._attr_name = f"{device.name} Battery"
         super().__init__(hilo, name=self._attr_name, device=device)
-        self._attr_unique_id = f"{slugify(device.name)}-battery"
+        old_unique_id = f"{slugify(device.name)}-battery"
+        self._attr_unique_id = f"{slugify(device.identifier)}-battery"
+        hilo.async_migrate_unique_id(
+            old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
         LOG.debug(f"Setting up BatterySensor entity: {self._attr_name}")
 
     @property
@@ -222,7 +226,11 @@ class Co2Sensor(HiloEntity, SensorEntity):
     def __init__(self, hilo, device):
         self._attr_name = f"{device.name} CO2"
         super().__init__(hilo, name=self._attr_name, device=device)
-        self._attr_unique_id = f"{slugify(device.name)}-co2"
+        old_unique_id = f"{slugify(device.name)}-co2"
+        self._attr_unique_id = f"{slugify(device.identifier)}-co2"
+        hilo.async_migrate_unique_id(
+            old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
         LOG.debug(f"Setting up CO2Sensor entity: {self._attr_name}")
 
     @property
@@ -298,7 +306,11 @@ class NoiseSensor(HiloEntity, SensorEntity):
     def __init__(self, hilo, device):
         self._attr_name = f"{device.name} Noise"
         super().__init__(hilo, name=self._attr_name, device=device)
-        self._attr_unique_id = f"{slugify(device.name)}-noise"
+        old_unique_id = f"{slugify(device.name)}-noise"
+        self._attr_unique_id = f"{slugify(device.identifier)}-noise"
+        hilo.async_migrate_unique_id(
+            old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
         LOG.debug(f"Setting up NoiseSensor entity: {self._attr_name}")
 
     @property

--- a/custom_components/hilo/switch.py
+++ b/custom_components/hilo/switch.py
@@ -1,5 +1,6 @@
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify
@@ -24,7 +25,11 @@ async def async_setup_entry(
 class HiloSwitch(HiloEntity, SwitchEntity):
     def __init__(self, hilo: Hilo, device):
         super().__init__(hilo, device=device, name=device.name)
-        self._attr_unique_id = f"{slugify(device.name)}-switch"
+        old_unique_id = f"{slugify(device.name)}-switch"
+        self._attr_unique_id = f"{slugify(device.identifier)}-switch"
+        hilo.async_migrate_unique_id(
+            old_unique_id, self._attr_unique_id, Platform.SWITCH
+        )
         LOG.debug(f"Setting up Switch entity: {self._attr_name}")
 
     @property


### PR DESCRIPTION
Les uniques IDs ne sont plus basé sur le nom des devices, mais sur leur identifier.
Donc maintenant si on renomme un device, il ne devient pas unavailable et toutes nos automatisation/configuration ne seront pas impacté.