### PR TITLE
Device tarif sensor hotfix

### DIFF
--- a/custom_components/hilo/manifest.json
+++ b/custom_components/hilo/manifest.json
@@ -11,6 +11,6 @@
   "documentation": "https://github.com/dvd-dev/hilo",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dvd-dev/hilo/issues",
-  "requirements": ["python-hilo>=2024.3.2"],
-  "version": "2024.3.1"
+  "requirements": ["python-hilo>=2024.3.1"],
+  "version": "2024.3.2"
 }

--- a/custom_components/hilo/manifest.json
+++ b/custom_components/hilo/manifest.json
@@ -11,6 +11,6 @@
   "documentation": "https://github.com/dvd-dev/hilo",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dvd-dev/hilo/issues",
-  "requirements": ["python-hilo>=2024.3.1"],
+  "requirements": ["python-hilo>=2024.3.2"],
   "version": "2024.3.1"
 }

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -146,7 +146,7 @@ async def async_setup_entry(
     def create_energy_entity(hilo, device):
         device._energy_entity = EnergySensor(hilo, device)
         new_entities.append(device._energy_entity)
-        energy_entity = f"hilo_energy_{slugify(device.name)}"
+        energy_entity = f"{slugify(device.name)}_hilo_energy"
         if energy_entity == HILO_ENERGY_TOTAL:
             LOG.error(
                 "An hilo entity can't be named 'total' because it conflicts "


### PR DESCRIPTION
Quickfix pour les energymeters _low et _medium des devices. En voulant différencier le unique id du nom je pense avoir causé un bug qui fait que leurs valeurs n'était plus populée car la source était érronée.

Testé en dev est c'est fonctionnel. Merci @turcotmii pour le cue.