### PR TITLE
Handle utility_meter Tariffs list to always exist

### DIFF
--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -583,7 +583,7 @@ class Hilo:
                     known_power += int(float(state.state))
                 except ValueError:
                     pass
-            if not entity.startswith("sensor.hilo_energy") or entity.endswith("_cost"):
+            if not entity.endswith("_hilo_energy") or entity.endswith("_cost"):
                 continue
             self.fix_utility_sensor(entity, state)
         if self.track_unknown_sources:
@@ -648,6 +648,21 @@ class Hilo:
         if self.untarificated_devices and entity != f"select.{HILO_ENERGY_TOTAL}":
             return
         if entity.startswith("select.hilo_energy") and current != new:
+            LOG.debug(
+                f"check_tarif: Changing tarif of {entity} from {current} to {new}"
+            )
+            context = Context()
+            data = {ATTR_OPTION: new, "entity_id": entity}
+            self._hass.async_create_task(
+                self._hass.services.async_call(
+                    SELECT_DOMAIN, SERVICE_SELECT_OPTION, data, context=context
+                )
+            )
+        if (
+            entity.startswith("select.")
+            and entity.endswith("_hilo_energy")
+            and current != new
+        ):
             LOG.debug(
                 f"check_tarif: Changing tarif of {entity} from {current} to {new}"
             )

--- a/custom_components/hilo/managers.py
+++ b/custom_components/hilo/managers.py
@@ -3,7 +3,10 @@ from datetime import timedelta
 
 from homeassistant.components.energy.data import async_get_manager
 from homeassistant.components.utility_meter import async_setup as utility_setup
-from homeassistant.components.utility_meter.const import DOMAIN as UTILITY_DOMAIN, CONF_TARIFFS
+from homeassistant.components.utility_meter.const import (
+    CONF_TARIFFS,
+    DOMAIN as UTILITY_DOMAIN,
+)
 from homeassistant.components.utility_meter.sensor import (
     async_setup_platform as utility_setup_platform,
 )
@@ -67,11 +70,15 @@ class UtilityManager:
             LOG.debug("No new entities, not setting up again")
             return
         config = {
-            UTILITY_DOMAIN: OrderedDict({**self.hass.data.get("utility_meter_data", {}), **self.meter_configs}),
+            UTILITY_DOMAIN: OrderedDict(
+                {**self.hass.data.get("utility_meter_data", {}), **self.meter_configs}
+            ),
             CONF_TARIFFS: self.tariffs,
         }
         await utility_setup(self.hass, config)
-        await utility_setup_platform(self.hass, config, async_add_entities, self.meter_entities)
+        await utility_setup_platform(
+            self.hass, config, async_add_entities, self.meter_entities
+        )
 
 
 class EnergyManager:

--- a/custom_components/hilo/manifest.json
+++ b/custom_components/hilo/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dvd-dev/hilo/issues",
   "requirements": ["python-hilo>=2024.3.1"],
-  "version": "2024.3.2"
+  "version": "2024.3.3"
 }

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -141,7 +141,7 @@ async def async_setup_entry(
         default_tariff_list = validate_tariff_list(tariff_config)
     if generate_energy_meters:
         energy_manager = await EnergyManager().init(hass, energy_meter_period)
-        utility_manager = UtilityManager(hass, energy_meter_period)
+        utility_manager = UtilityManager(hass, energy_meter_period, default_tariff_list)
 
     def create_energy_entity(hilo, device):
         device._energy_entity = EnergySensor(hilo, device)


### PR DESCRIPTION
Hi all,

This should be fixing the problem where the utility meter setup could fail because the configuration for tariff wasn't being passed by default (at least an empty list).

This is untested as I do not have the setup to test it locally.  I will try to adjust.

Fix #365