### PR TITLE
Update des supported color modes pour corriger le warning...

### DIFF
--- a/custom_components/hilo/light.py
+++ b/custom_components/hilo/light.py
@@ -73,13 +73,14 @@ class HiloLight(HiloEntity, LightEntity):
     @property
     def supported_color_modes(self) -> set:
         """Flag supported modes."""
-        supports = set()
-        supports.add(ColorMode.ONOFF)
-        if self._device.has_attribute("intensity"):
-            supports.add(ColorMode.BRIGHTNESS)
+        color_modes = set()
         if self._device.has_attribute("hue"):
-            supports.add(ColorMode.HS)
-        return supports
+            color_modes.add(ColorMode.HS)
+        if not color_modes and self._device.has_attribute("intensity"):
+            color_modes.add(ColorMode.BRIGHTNESS)
+        if not color_modes:
+            color_modes.add(ColorMode.ONOFF)
+        return color_modes
 
     async def async_turn_off(self, **kwargs):
         LOG.info(f"{self._device._tag} Turning off")


### PR DESCRIPTION
...HiloLight sets invalid supported color modes

Corrige cette erreur:
![image](https://github.com/dvd-dev/hilo/assets/44422604/75f07720-cba6-48ad-84c2-325c3a7c3540)

J'ai pas testé avec les ampoules RGB par contre puisque j'en ai pas mais seslon mes recherches ça devrait être ok.

Le warning est apparue suite à la mise à jour 2024.3 de HA. On settait le color_mode mais par correctement.

https://developers.home-assistant.io/blog/2024/02/12/light-color-mode-mandatory/

ColorMode.ONOFF ou ColorMode.BRIGHTNESS doivent être le seul mode supporté par la lumière quand ils sont déclaré.
https://developers.home-assistant.io/docs/core/entity/light/#color-modes