### PR TITLE
Fix pour issue 400

### DIFF
--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -254,7 +254,6 @@ class EnergySensor(IntegrationSensor):
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
-    _attr_suggested_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
     _attr_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
     _attr_icon = "mdi:lightning-bolt"
 
@@ -540,7 +539,6 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
 
     _attr_device_class = SensorDeviceClass.MONETARY
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
-    _attr_suggested_unit_of_measurement = "CAD"
     _entity_component_unrecorded_attributes = frozenset({"history"})
 
     def __init__(self, hilo, device, scan_interval):


### PR DESCRIPTION
Ces unités suggérées ne sont plus valides. Vérifié dans le codebase de HA et elles sont maintenant natives donc on n'en a plus besoin.

Testé en dev sur un fresh install car n'aurait pas d'effet sur un installation existante, fonctionne tel qu'attendu.