### PR TITLE
Update des tarifs d'Hydro

### DIFF
--- a/custom_components/hilo/const.py
+++ b/custom_components/hilo/const.py
@@ -48,18 +48,18 @@ REWARD_SCAN_INTERVAL = 7200
 CONF_TARIFF = {
     "rate d": {
         "low_threshold": 40,
-        "low": 0.06509,
-        "medium": 0.10041,
+        "low": 0.06704,
+        "medium": 0.10342,
         "high": 0,
-        "access": 0.43505,
+        "access": 0.44810,
         "reward_rate": 0.55,
     },
     "flex d": {
         "low_threshold": 40,
-        "low": 0.04582,
-        "medium": 0.07880,
-        "high": 0.53526,
-        "access": 0.43505,
+        "low": 0.04719,
+        "medium": 0.08116,
+        "high": 0.55132,
+        "access": 0.44810,
         "reward_rate": 0.55,
     },
 }


### PR DESCRIPTION
Un ajustement tarifaire moyen de 3 % est entré en vigueur le 1er avril dernier.   Ref: [Grille des tarifs d’électricité](https://www.hydroquebec.com/data/documents-donnees/pdf/grille-tarifaire.pdf?v=20191202)

Par contre le tarif de récompense n'a toujours pas augmenté (0,55 $/kWh)...