### PR TITLE
Link energysensor devices

### DIFF
--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -1,4 +1,5 @@
 """Support for various Hilo sensors."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
@@ -24,6 +25,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import Throttle, slugify
@@ -275,6 +277,9 @@ class EnergySensor(IntegrationSensor):
         initial_state = 0
         self._attr_native_value = initial_state
         self._attr_last_valid_state = initial_state
+        self._device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device.identifier)},
+        )
 
         super().__init__(
             integration_method=METHOD_LEFT,
@@ -284,6 +289,7 @@ class EnergySensor(IntegrationSensor):
             unique_id=self._attr_unique_id,
             unit_prefix="k",
             unit_time="h",
+            device_info=self._device_info,
         )
         LOG.debug(
             f"Setting up EnergySensor entity: {self._attr_name} with source {self._source}"

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -257,7 +257,6 @@ class EnergySensor(IntegrationSensor):
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
-    _attr_icon = "mdi:lightning-bolt"
 
     def __init__(self, hilo, device):
         self._device = device
@@ -291,6 +290,7 @@ class EnergySensor(IntegrationSensor):
             unit_time="h",
             device_info=self._device_info,
         )
+        self._attr_icon = "mdi:lightning-bolt"
         LOG.debug(
             f"Setting up EnergySensor entity: {self._attr_name} with source {self._source}"
         )


### PR DESCRIPTION
Le sensor d'energy est linker à son device.
J'ai aussi déplacé l'attribution de l'icone car elle n'était pas affiché partout correctement. En le mettant avant l'init de l'integrationsensor il était overwriter par l'icone définit dans sa déclaration (self._attr_icon = "mdi:chart-histogram").
Mais maintenant c'est l'inverse c'est nous qui overwiter l'icone.

Voici le résultat:
![image](https://github.com/dvd-dev/hilo/assets/44422604/d470cadb-8215-48f7-b1fc-9dc87e24c4c0)
