### PR TITLE
retrait du hardcoding de meter00

### DIFF
--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -569,10 +569,10 @@ class Hilo:
         # smart_meter = "sensor.meter00_power" #retrait de cette ligne pour le block suivant
         # fix Mig :: definition du smart_meter ; loop sur les entités pour trouver soit "meter00" ou "smartenergymeter_power"
         for meter_scan in self._hass.states.async_all():
-            entity1 = meter_scan.entity_id
-            if (entity1.endswith("_power") and entity1.find("meter") > 0):
-                smart_meter = entity1
-                LOG.debug(f"576: setting smart_meter for {entity1}")
+            entity_lookup = meter_scan.entity_id
+            if entity_lookup.endswith("_power") and entity_lookup.find("meter") > 0:
+                smart_meter = entity_lookup
+                LOG.debug(f"576: setting smart_meter for {entity_lookup}")
         unknown_source_tracker = "sensor.unknown_source_tracker_power"
         for state in self._hass.states.async_all():
             entity = state.entity_id

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -601,7 +601,7 @@ class Hilo:
             )
         known_power = 0
         smart_meter = self.find_meter(self._hass)  # comes from find_meter function
-        LOG.debug(f"Smart meter used current is: {smart_meter}")
+        LOG.debug(f"Smart meter used currently is: {smart_meter}")
 
         unknown_source_tracker = "sensor.unknown_source_tracker_power"
         for state in self._hass.states.async_all():

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -566,11 +566,11 @@ class Hilo:
                 f"check_tarif: Current plan: {plan_name} Target Tarif: {tarif} Energy used: {energy_used.state} Peak: {self.high_times}"
             )
         known_power = 0
-        #smart_meter = "sensor.meter00_power" #retrait de cette ligne pour le block suivant
-        #fix Mig :: definition du smart_meter ; loop sur les entités pour trouver soit "meter00" ou "smartenergymeter_power"
+        # smart_meter = "sensor.meter00_power" #retrait de cette ligne pour le block suivant
+        # fix Mig :: definition du smart_meter ; loop sur les entités pour trouver soit "meter00" ou "smartenergymeter_power"
         for meter_scan in self._hass.states.async_all():
             entity1 = meter_scan.entity_id
-            if entity1.endswith("_power") and entity1.find("meter")>0:
+            if entity1.endswith("_power") and entity1.find("meter") > 0:
                 smart_meter = entity1
                 LOG.debug(f"576: setting smart_meter for {entity1}")
         unknown_source_tracker = "sensor.unknown_source_tracker_power"

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -514,35 +514,33 @@ class Hilo:
     def find_meter(self, hass):
         entity_registry_dict = {}
 
-        # ic-dev21 on interroge le entity registry de hass.data ici:
         registry = hass.data.get("entity_registry")
 
-        # ic-dev21 on gère le cas d'un registry vide
         if registry is None:
             return entity_registry_dict
 
-        # ic-dev21: on va chercher le nom, peut-être qu'on devrait pogner la platform pour ramasser tout hilo?
+        # ic-dev21: Get names of all entities
         for entity_id, entity_entry in registry.entities.items():
             entity_registry_dict[entity_id] = {
                 "name": entity_entry.entity_id,
             }
 
-        # ic-dev21 je trie le résultat, pourrait probablement être enlevé mais facilite la lecture en debug
         sorted_entity_registry_dict = OrderedDict(sorted(entity_registry_dict.items()))
-        LOG.debug(f"Hilo Ordered dict is {sorted_entity_registry_dict}")
+        LOG.debug(f"Entities Ordered dict is {sorted_entity_registry_dict}")
 
-        # ici j'initialise la liste vide
+        # Initialize empty list to put meter name into
         filtered_names = []
 
-        # ic-dev21 je sors juste ce qui nous intéresse
+        # ic-dev21: Let's grab the meter from our dict
         for entity_id, entity_data in sorted_entity_registry_dict.items():
             if all(
                 substring in entity_data["name"] for substring in ["meter", "_power"]
             ):
                 filtered_names.append(entity_data["name"])
 
-        LOG.debug(f"Current meter names are: {filtered_names}")
+        LOG.debug(f"Hilo Smart meter name is: {filtered_names}")
 
+        # Format output to use in check_tarif
         return ", ".join(filtered_names) if filtered_names else ""
 
     def set_state(self, entity, state, new_attrs={}, keep_state=False, force=False):
@@ -602,7 +600,7 @@ class Hilo:
                 f"check_tarif: Current plan: {plan_name} Target Tarif: {tarif} Energy used: {energy_used.state} Peak: {self.high_times}"
             )
         known_power = 0
-        smart_meter = self.find_meter(self._hass)
+        smart_meter = self.find_meter(self._hass)  # comes from find_meter function
         LOG.debug(f"Smart meter used current is: {smart_meter}")
 
         unknown_source_tracker = "sensor.unknown_source_tracker_power"

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -570,8 +570,7 @@ class Hilo:
         # fix Mig :: definition du smart_meter ; loop sur les entités pour trouver soit "meter00" ou "smartenergymeter_power"
         for meter_scan in self._hass.states.async_all():
             entity1 = meter_scan.entity_id
-            if (entity1.endswith("_power") and 
-                entity1.find("meter") > 0):
+            if (entity1.endswith("_power") and entity1.find("meter") > 0):
                 smart_meter = entity1
                 LOG.debug(f"576: setting smart_meter for {entity1}")
         unknown_source_tracker = "sensor.unknown_source_tracker_power"

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -570,7 +570,8 @@ class Hilo:
         # fix Mig :: definition du smart_meter ; loop sur les entités pour trouver soit "meter00" ou "smartenergymeter_power"
         for meter_scan in self._hass.states.async_all():
             entity1 = meter_scan.entity_id
-            if entity1.endswith("_power") and entity1.find("meter") > 0:
+            if (entity1.endswith("_power") and 
+                entity1.find("meter") > 0):
                 smart_meter = entity1
                 LOG.debug(f"576: setting smart_meter for {entity1}")
         unknown_source_tracker = "sensor.unknown_source_tracker_power"

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -566,7 +566,13 @@ class Hilo:
                 f"check_tarif: Current plan: {plan_name} Target Tarif: {tarif} Energy used: {energy_used.state} Peak: {self.high_times}"
             )
         known_power = 0
-        smart_meter = "sensor.meter00_power"
+        #smart_meter = "sensor.meter00_power" #retrait de cette ligne pour le block suivant
+        #fix Mig :: definition du smart_meter ; loop sur les entités pour trouver soit "meter00" ou "smartenergymeter_power"
+        for meter_scan in self._hass.states.async_all():
+            entity1 = meter_scan.entity_id
+            if entity1.endswith("_power") and entity1.find("meter")>0:
+                smart_meter = entity1
+                LOG.debug(f"576: setting smart_meter for {entity1}")
         unknown_source_tracker = "sensor.unknown_source_tracker_power"
         for state in self._hass.states.async_all():
             entity = state.entity_id

--- a/custom_components/hilo/manifest.json
+++ b/custom_components/hilo/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dvd-dev/hilo/issues",
   "requirements": ["python-hilo>=2024.4.1"],
-  "version": "2024.4.3"
+  "version": "2024.4.4"
 }

--- a/custom_components/hilo/manifest.json
+++ b/custom_components/hilo/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dvd-dev/hilo/issues",
   "requirements": ["python-hilo>=2024.4.1"],
-  "version": "2024.4.4"
+  "version": "2024.4.3"
 }


### PR DESCRIPTION
conflit entre certaines installation qui possede le meter00 et smartenergymeter_power.

Remplacement de la ligne #569
#smart_meter = "sensor.meter00_power"

par un bout de code qui scan les entités de l'instance HA et qui contiendrait le terme 'meter' et se termine par '_power'