### PR TITLE
Outdoor weather: Changed Condition log level to decrease verbosity

### DIFF
--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -873,7 +873,7 @@ class HiloOutdoorTempSensor(HiloEntity, SensorEntity):
     @property
     def icon(self):
         condition = self._weather.get("condition", "").lower()
-        LOG.warning(f"Current condition: {condition}")
+        LOG.debug(f"Current condition: {condition}")
         if not condition:
             return "mdi:lan-disconnect"
         return WEATHER_CONDITIONS.get(self._weather.get("condition", "Unknown"))


### PR DESCRIPTION
Current log level for a given property is set to "warning" and is a bit too verbose in the logs :)