### PR TITLE
Files operation async

### DIFF
--- a/custom_components/hilo/manifest.json
+++ b/custom_components/hilo/manifest.json
@@ -11,6 +11,6 @@
   "documentation": "https://github.com/dvd-dev/hilo",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dvd-dev/hilo/issues",
-  "requirements": ["python-hilo>=2024.4.1"],
-  "version": "2024.6.1"
+  "requirements": ["python-hilo>=2024.6.1"],
+  "version": "2024.6.2"
 }


### PR DESCRIPTION
Rendu les opérations de fichiers sur l'historique des défis async pour régler le chialage dans le log sur les blocking calls, voir #434.

Bump up verion 2024.6.2

Testé sur un install neuf, sur un install existant en deletant le fichier hilo_event_history.yaml et aussi en en enlevant des bouts.

Fixes #434