### PR TITLE
Fixed AM anchor time condition in automation example

### DIFF
--- a/doc/automations/README.md
+++ b/doc/automations/README.md
@@ -150,8 +150,8 @@ condition:
         entity_id: sensor.defi_hilo
         state: scheduled
   - condition: time
-    after: "11:55:00"
-    before: "12:05:00"
+    after: "00:55:00"
+    before: "01:05:00"
 action:
   - choose:
       - conditions:


### PR DESCRIPTION
Fixed AM anchor time condition to be between 00:55:00 (12:55am) and 01:05:00 (1:05am). Before it was the same as PM anchor time conditions, which should not be the case.