### PR TITLE
Ajout version check pour config_entry init dans config_flow 

### DIFF
--- a/custom_components/hilo/config_flow.py
+++ b/custom_components/hilo/config_flow.py
@@ -156,6 +156,8 @@ class HiloOptionsFlowHandler(config_entries.OptionsFlow):
         """Initialize"""
         if AwesomeVersion(HAVERSION) < "2024.11.99":
             self.config_entry = config_entry
+        else:
+            self._config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/hilo/config_flow.py
+++ b/custom_components/hilo/config_flow.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from awesomeversion import AwesomeVersion
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_SCAN_INTERVAL
+from homeassistant.const import CONF_SCAN_INTERVAL, __version__ as HAVERSION
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv, selector
@@ -152,8 +153,9 @@ class HiloOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a Hilo options flow."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize."""
-        self._config_entry = config_entry
+        """Initialize"""
+        if AwesomeVersion(HAVERSION) < "2024.11.99":
+            self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
Le config_entry init dans le config_flow.py est no longer allowed dans HA > 24.11.99 selon l'information trouvé dans le repo de HACS : https://github.com/hacs/integration/pull/4181

J'ai ajouté le même version check que dans la PR mentionné. 