### PR TITLE
Get entity id from unique

### DIFF
--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -723,6 +723,19 @@ class Hilo:
             )
 
     @callback
+    def async_get_entity_id_domain(self, platform: str, unique_id: str) -> str | None:
+        entity_registry = er.async_get(self._hass)
+        entity_id = entity_registry.async_get_entity_id(platform, DOMAIN, unique_id)
+        LOG.debug(
+            "%s-%s:For unique_id get entity_id (%s -> %s)",
+            DOMAIN,
+            platform,
+            unique_id,
+            entity_id,
+        )
+        return entity_id
+
+    @callback
     def async_migrate_unique_id(
         self, old_unique_id: str, new_unique_id: str | None, platform: str
     ) -> None:

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -286,7 +286,14 @@ class EnergySensor(IntegrationSensor):
 
         if device.type == "Meter":
             self._attr_name = HILO_ENERGY_TOTAL
-        self._source = f"sensor.{slugify(device.name)}_power"
+        power_unique_id = f"{slugify(device.identifier)}-power"
+        if (
+            power_entity_id := hilo.async_get_entity_id_domain(
+                Platform.SENSOR, power_unique_id
+            )
+        ) is None:
+            power_entity_id = f"{Platform.SENSOR}.{slugify(device.name)}_power"
+        self._source = power_entity_id
         # ic-dev21: Set initial state and last_valid_state, removes log errors and unavailable states
         initial_state = 0
         self._attr_native_value = initial_state

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -166,12 +166,7 @@ async def async_setup_entry(
         ) is None:
             energy_entity = f"sensor.{slugify(device.name)}_hilo_energy"
         energy_entity = energy_entity.replace("sensor.", "")
-        if energy_entity == HILO_ENERGY_TOTAL:
-            LOG.error(
-                "An hilo entity can't be named 'total' because it conflicts "
-                "with the generated name for the smart energy meter"
-            )
-            return
+
         tariff_list = default_tariff_list
         if device.type == "Meter":
             tariff_list = validate_tariff_list(tariff_config)


### PR DESCRIPTION
Pour linker les energysensors aux entités correspondantes l'intégration utilisait le nom de l'entité donc ce n'était pas nécéssairement la bonne entité de linker. Maintenant l'intégration utilise le uniqueID pour les linker.

Devrait corriger #524