### PR TITLE
Add a devcontainer for VSCode setup

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "dvd-dev/hilo",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  "postCreateCommand": "scripts/setup",
+  "forwardPorts": [8123],
+  "portsAttributes": {
+    "8123": {
+      "label": "Home Assistant",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "charliermarsh.ruff",
+        "github.vscode-pull-request-github",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ryanluker.vscode-coverage-gutters"
+      ],
+      "settings": {
+        "files.eol": "\n",
+        "editor.tabSize": 4,
+        "editor.formatOnPaste": true,
+        "editor.formatOnSave": true,
+        "editor.formatOnType": false,
+        "files.trimTrailingWhitespace": true,
+        "python.analysis.typeCheckingMode": "basic",
+        "python.analysis.autoImportCompletions": true,
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff"
+        }
+      }
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,11 @@ venv
 .vscode
 .DS_Store
 .idea*
+
+# Home Assistant configuration
+config/*
+!config/configuration.yaml
+
+# Hilo configuration
+hilo_eventhistory_state.yaml
+hilo_state.yaml

--- a/README.en.md
+++ b/README.en.md
@@ -263,60 +263,20 @@ logger:
 
 If you have any kind of python/home-assistant experience and want to contribute to the code, feel free to submit a pull request.
 
-### Prepare a dev  environment in MacOS / Linux
+### Prepare a development environment via VSCode DevContainer
 
-1. Prepare necessary directories:
-```console
-$ HASS_DEV=~/hass-dev/
-$ HASS_RELEASE=2023.12.3
-$ mkdir -p ${HASS_DEV}/config
-$ cd $HASS_DEV
-$ git clone https://github.com/dvd-dev/hilo.git
-$ git clone https://github.com/dvd-dev/python-hilo.git
-$ git clone https://github.com/home-assistant/core.git
-$ git --git-dir core/ checkout $HASS_RELEASE
-```
+To facilitate development, a development environment is available via VSCode DevContainer. To use it, you must have [VSCode](https://code.visualstudio.com/) and [Docker](https://www.docker.com/) installed on your computer.
 
-**NOTE**: We also clone home-assistant's core to make it easier to add logging at that level [repo](https://github.com/home-assistant/core).
-
-2. Launch the container:
-
-```console
-$ docker run -d -p 8123:8123 \
-  --name hass \
-  -v ${HASS_DEV}/config:/config \
-  -v ${HASS_DEV}/python-hilo/pyhilo:/usr/local/lib/python3.11/site-packages/pyhilo:ro \
-  -v ${HASS_DEV}/hilo/custom_components/hilo/:/config/custom_components/hilo:ro \
-  -v ${HASS_DEV}/core/homeassistant:/usr/src/homeassistant/homeassistant:ro \
-  homeassistant/home-assistant:$HASS_RELEASE
-```
-
-3. Check the container is running
-
-```console
-$ docker ps
-CONTAINER ID   IMAGE                                    COMMAND   CREATED       STATUS          PORTS                    NAMES
-bace2264ee54   homeassistant/home-assistant:2023.12.3   "/init"   3 hours ago   Up 28 minutes   0.0.0.0:8123->8123/tcp   hass
-```
-
-4. Check home-assistant logs
-```console
-$ less ${HASS_DEV}/config/home-assistant.log
-$ grep hilo ${HASS_DEV}/config/home-assistant.log
-```
-
-5. Activate debug logs
-
-```console
-$ cat << EOF >> ${HASS_DEV}/config/configuration.yaml
-logger:
-  default: info
-  logs:
-     custom_components.hilo: debug
-     pyhilo: debug
-EOF
-$ docker restart hass
-```
+1. Open the project folder in VSCode
+2. Install the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
+3. Open the command palette (Ctrl+Shift+P or Cmd+Shift+P) and search for "Remote-Containers: Reopen in Container"
+4. Wait for the environment to be ready
+5. Open a terminal in VSCode and run `scripts/develop` to install dependencies and start Home Assistant
+6. At this point, VSCode should prompt you to open a browser to access Home Assistant. You can also open a browser manually and go to [http://localhost:8123](http://localhost:8123)
+7. You will need to do the initial Home Assistant configuration
+8. You will need to add the Hilo integration via the user interface
+9. You can now modify files in the `custom_components/hilo` folder and see changes in real-time in Home Assistant
+10. In the terminal where you launched `scripts/develop`, Home Assistant and HILO integration logs should be streamed
 
 ### Before submitting a Pull Request
 

--- a/README.md
+++ b/README.md
@@ -245,60 +245,20 @@ logger:
 
 Si vous avez de l'expérience python ou Home Assistant et que vous souhaitez contribuer au code, n'hésitez pas à soumettre un pull request.
 
-### Préparer un environnement de développement sur macOS / Linux
+### Préparer un environnement de développement via VSCode DevContainer
 
-1. Préparer les dossiers nécessaires:
-```console
-$ HASS_DEV=~/hass-dev/
-$ HASS_RELEASE=2023.12.3
-$ mkdir -p ${HASS_DEV}/config
-$ cd $HASS_DEV
-$ git clone https://github.com/dvd-dev/hilo.git
-$ git clone https://github.com/dvd-dev/python-hilo.git
-$ git clone https://github.com/home-assistant/core.git
-$ git --git-dir core/ checkout $HASS_RELEASE
-```
+Pour faciliter le développement, un environnement de développement est disponible via DevContainer de VSCode. Pour l'utiliser, vous devez avoir [VSCode](https://code.visualstudio.com/) et [Docker](https://www.docker.com/) installés sur votre ordinateur.
 
-**NOTE**: On clone aussi le [repo](https://github.com/home-assistant/core) de home-assistant, car c'est plus facile d'ajouter du debug à ce niveau.
-
-2. Lancer le container:
-
-```console
-$ docker run -d -p 8123:8123 \
-  --name hass \
-  -v ${HASS_DEV}/config:/config \
-  -v ${HASS_DEV}/python-hilo/pyhilo:/usr/local/lib/python3.11/site-packages/pyhilo:ro \
-  -v ${HASS_DEV}/hilo/custom_components/hilo/:/config/custom_components/hilo:ro \
-  -v ${HASS_DEV}/core/homeassistant:/usr/src/homeassistant/homeassistant:ro \
-  homeassistant/home-assistant:$HASS_RELEASE
-```
-
-3. Vérifier que le container roule
-
-```console
-$ docker ps
-CONTAINER ID   IMAGE                                    COMMAND   CREATED       STATUS          PORTS                    NAMES
-bace2264ee54   homeassistant/home-assistant:2023.12.3   "/init"   3 hours ago   Up 28 minutes   0.0.0.0:8123->8123/tcp   hass
-```
-
-4. Vérifier les logs de home-assistant
-```console
-$ less ${HASS_DEV}/config/home-assistant.log
-$ grep hilo ${HASS_DEV}/config/home-assistant.log
-```
-
-5. Activer les logs debug
-
-```console
-$ cat << EOF >> ${HASS_DEV}/config/configuration.yaml
-logger:
-  default: info
-  logs:
-     custom_components.hilo: debug
-     pyhilo: debug
-EOF
-$ docker restart hass
-```
+1. Ouvrir le dossier du projet dans VSCode
+2. Installer l'extension [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+3. Ouvrir la palette de commande (Ctrl+Shift+P ou Cmd+Shift+P) et chercher "Remote-Containers: Reopen in Container"
+4. Attendre que l'environnement soit prêt
+5. Ouvrir un terminal dans VSCode et exécuter `scripts/develop` pour installer les dépendances et lancer Home Assistant.
+6. VSCode devrait vous proposer d'ouvrir un navigateur pour accéder à Home Assistant. Vous pouvez aussi ouvrir un navigateur manuellement et accéder à [http://localhost:8123](http://localhost:8123).
+7. Vous allez devoir faire la configuration initiale de Home Assistant.
+8. Vous allez devoir ajouter l'intégration Hilo via l'interface utilisateur.
+9. Vous pouvez maintenant modifier les fichiers dans le dossier `custom_components/hilo` et voir les changements en temps réel dans Home Assistant.
+10. Dans le terminal ou vous avez lancé `scripts/develop`, les logs de Home Assistant et de l'intégration HILO devraient défiler.
 
 ### Avant de soumettre une Pull Request
 

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,0 +1,15 @@
+# This file is only used by the Devcontainer
+# https://www.home-assistant.io/integrations/default_config/
+default_config:
+
+# https://www.home-assistant.io/integrations/homeassistant/
+homeassistant:
+  debug: true
+
+# https://www.home-assistant.io/integrations/logger/
+logger:
+  default: info
+  logs:
+    # Enable debug logging for our custom components
+    custom_components.hilo: debug
+    pyhilo: debug

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+colorlog==6.9.0
+homeassistant~=2025.1.0
+pip>=21.3.1
+ruff==0.9.1

--- a/scripts/develop
+++ b/scripts/develop
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# Create config dir if not present
+if [[ ! -d "${PWD}/config" ]]; then
+    mkdir -p "${PWD}/config"
+    hass --config "${PWD}/config" --script ensure_config
+fi
+
+# Set the path to custom_components
+## This let's us have the structure we want <root>/custom_components/hilo
+## while at the same time have Home Assistant configuration inside <root>/config
+## without resulting to symlinks.
+export PYTHONPATH="${PYTHONPATH}:${PWD}/custom_components"
+
+# Start Home Assistant
+hass --config "${PWD}/config" --debug

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+python3 -m pip install --requirement requirements.txt


### PR DESCRIPTION
This commit adds a devcontainer configuration for VSCode to facilitate development. It also adds a script to setup the development environment and start Home Assistant.

This setups heavily borrows from https://github.com/ludeeus/integration_blueprint (from which this repo was initially derived).
<img width="1552" alt="Screenshot 2025-01-28 at 1 03 21 AM" src="https://github.com/user-attachments/assets/29f5d0d2-368d-430d-9ddc-0e7694ff477f" />
<img width="1552" alt="Screenshot 2025-01-28 at 1 04 01 AM" src="https://github.com/user-attachments/assets/9c18f49c-5f0d-47bf-91ef-8187a31b0355" />

This is a first PR from where I'll be building on. My plan is to align the setting as much as possible with Home Assistant and the blueprint template themselves. 
I plan to improve the setup and instructions in the future to document how to run a custom version of `py-hilo`.
