### PR TITLE
Reduce the race condition probability

### DIFF
--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -776,7 +776,7 @@ class HiloChallengeSensor(HiloEntity, RestoreEntity, SensorEntity):
             self._next_events = last_state.attributes.get("next_events", [])
 
     async def _async_update(self):
-        self._next_events = []
+        tmp_next_events = []
         events = await self._hilo._api.get_gd_events(self._hilo.devices.location_id)
         LOG.debug(f"Events received from Hilo: {events}")
         for raw_event in events:
@@ -786,7 +786,8 @@ class HiloChallengeSensor(HiloEntity, RestoreEntity, SensorEntity):
                 event.appreciation(self._hilo.appreciation)
             if self._hilo.pre_cold > 0:
                 event.pre_cold(self._hilo.pre_cold)
-            self._next_events.append(event.as_dict())
+            tmp_next_events.append(event.as_dict())
+        self._next_events = tmp_next_events
 
 
 class DeviceSensor(HiloEntity, SensorEntity):


### PR DESCRIPTION
Small change which should fix most of the "glitches" observed where the defi_hilo state goes to "off" for no reason.

This PR slightly changes the way the `_next_events` list is updated, significantly reducing the race condition time window. Instead of clearing the list and performing a network call afterwards, we perform the network call, populate a temp list and then assign the content of the temp list to `_next_events` 