### PR TITLE
Monkeypatch pyhilo

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -19,6 +19,12 @@ This is a beta release. There will be some bugs, issues, etc. Please bear with u
 # Hilo
 [Hilo](https://www.hydroquebec.com/hilo/en/) integration for Home Assistant
 
+# :warning: Breaking change to come, update to 2025.2.1 in the meantime
+
+The API we rely on for Hilo Challenges will be closed in the near future, we are currently working on an alternative
+using Websockets/SignalR. **Updating to 2025.2.1 is strongly suggested** as prior version will likely break due to the way
+pip installs dependencies.
+
 ## Introduction
 
 This is the unofficial HACS Hilo integration for Home Assistant. [Hilo](https://www.hiloenergie.com/en-ca/) is a smart home platform developed

--- a/README.en.md
+++ b/README.en.md
@@ -19,7 +19,7 @@ This is a beta release. There will be some bugs, issues, etc. Please bear with u
 # Hilo
 [Hilo](https://www.hydroquebec.com/hilo/en/) integration for Home Assistant
 
-# :warning: Breaking change to come, update to 2025.2.1 in the meantime
+# :warning: Breaking change to come, update to 2025.2.1 in the meantime :warning:
 
 The API we rely on for Hilo Challenges will be closed in the near future, we are currently working on an alternative
 using Websockets/SignalR. **Updating to 2025.2.1 is strongly suggested** as prior version will likely break due to the way

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Ceci est une version Bêta. Il y aura probablement des bogues, irritants, etc. M
 # Hilo
 Intégration pour Home Assistant d'[Hilo](https://www.hydroquebec.com/hilo/fr/)
 
-# :warning: Changement majeur à venir, mettez à jour vers 2025.2.1 en attendant.
+# :warning: Changement majeur à venir, mettez à jour vers 2025.2.1 en attendant. :warning:
 
 L'API sur laquelle nous comptons pour les défis Hilo sera fermée prochainement. Nous travaillons actuellement sur une 
 alternative utilisant Websockets/SignalR. **La mise à jour vers la version 2025.2.1 est fortement recommandée**, car 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Intégration pour Home Assistant d'[Hilo](https://www.hydroquebec.com/hilo/fr/)
 
 # :warning: Changement majeur à venir, mettez à jour vers 2025.2.1 en attendant. :warning:
 
-L'API sur laquelle nous comptons pour les défis Hilo sera fermée prochainement. Nous travaillons actuellement sur une 
-alternative utilisant Websockets/SignalR. **La mise à jour vers la version 2025.2.1 est fortement recommandée**, car 
+L'API sur laquelle nous comptons pour les défis Hilo sera fermée prochainement. Nous travaillons actuellement sur une
+alternative utilisant Websockets/SignalR. **La mise à jour vers la version 2025.2.1 est fortement recommandée**, car
 les versions précédentes risquent de ne plus fonctionner en raison de la façon dont pip installe les dépendances.
 
 ## Introduction et base

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Ceci est une version Bêta. Il y aura probablement des bogues, irritants, etc. M
 # Hilo
 Intégration pour Home Assistant d'[Hilo](https://www.hydroquebec.com/hilo/fr/)
 
+# :warning: Changement majeur à venir, mettez à jour vers 2025.2.1 en attendant.
+
+L'API sur laquelle nous comptons pour les défis Hilo sera fermée prochainement. Nous travaillons actuellement sur une 
+alternative utilisant Websockets/SignalR. **La mise à jour vers la version 2025.2.1 est fortement recommandée**, car 
+les versions précédentes risquent de ne plus fonctionner en raison de la façon dont pip installe les dépendances.
+
 ## Introduction et base
 
 Ceci est l'intégration HACS non-officielle de Hilo sur Home Assistant. [Hilo](https://www.hiloenergie.com/fr-ca/) est une plateforme de domotique développée par une filliale d'[Hydro-Québec](https://www.hydroquebec.com/hilo/fr/).

--- a/custom_components/hilo/manifest.json
+++ b/custom_components/hilo/manifest.json
@@ -11,6 +11,6 @@
   "documentation": "https://github.com/dvd-dev/hilo",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dvd-dev/hilo/issues",
-  "requirements": ["python-hilo>=2024.10.2"],
-  "version": "2025.1.1"
+  "requirements": ["python-hilo==2024.10.2"],
+  "version": "2025.2.1"
 }


### PR DESCRIPTION
Fixer la version de pyhilo à 2024.10.2. Lorsque la transition vers le websocket sera terminée, ne pas faire ça ferait que des vieux install sous l'API briserait à cause des dépendances dans pyhilo.