### PR TITLE
Allow working on python-hilo at the same time as hilo

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,9 @@
 {
   "name": "dvd-dev/hilo",
   "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  // This is required because there is no conditional mount support in devcontainers.
+  // We create the python-hilo directory if it doesn't exist.
+  "initializeCommand": "mkdir -p ${localWorkspaceFolder}/../python-hilo || true",
   "postCreateCommand": "scripts/setup",
   "forwardPorts": [8123],
   "portsAttributes": {
@@ -34,5 +37,8 @@
       }
     }
   },
-  "remoteUser": "vscode"
+  "remoteUser": "vscode",
+  "mounts": [
+    "source=${localWorkspaceFolder}/../python-hilo,target=/workspaces/python-hilo,type=bind,consistency=cached"
+  ]
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,8 @@ repos:
     rev: v2.4.0
     hooks:
       - id: check-json
+        # Exclude .devcontainer.json since it uses JSONC
+        exclude: .devcontainer.json
       - id: no-commit-to-branch
         args:
           - --branch=main

--- a/README.en.md
+++ b/README.en.md
@@ -275,6 +275,12 @@ To facilitate development, a development environment is available via VSCode Dev
 
 1. Open the project folder in VSCode
 2. Install the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
+3. If you want to work on `python-hilo` at the same time, you need to clone the [python-hilo repository](https://github.com/dvd-dev/python-hilo) in a folder adjacent to the `hilo` folder. The `python-hilo` folder name is **REQUIRED** for the development environment to work properly. ex:
+
+        parent_folder/
+        ├── hilo/
+        └── python-hilo/
+
 3. Open the command palette (Ctrl+Shift+P or Cmd+Shift+P) and search for "Remote-Containers: Reopen in Container"
 4. Wait for the environment to be ready
 5. Open a terminal in VSCode and run `scripts/develop` to install dependencies and start Home Assistant

--- a/README.md
+++ b/README.md
@@ -257,6 +257,12 @@ Pour faciliter le développement, un environnement de développement est disponi
 
 1. Ouvrir le dossier du projet dans VSCode
 2. Installer l'extension [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+3. Si vous souhaitez travailler en même temps sur `python-hilo`, vous devez cloner le [repository python-hilo](https://github.com/dvd-dev/python-hilo) dans un dossier adjacent à celui de `hilo`. Le nom du dossier `python-hilo` est **REQUIS** pour que l'environnement de développement fonctionne correctement. ex:
+
+        parent_folder/
+        ├── hilo/
+        └── python-hilo/
+
 3. Ouvrir la palette de commande (Ctrl+Shift+P ou Cmd+Shift+P) et chercher "Remote-Containers: Reopen in Container"
 4. Attendre que l'environnement soit prêt
 5. Ouvrir un terminal dans VSCode et exécuter `scripts/develop` pour installer les dépendances et lancer Home Assistant.

--- a/scripts/develop
+++ b/scripts/develop
@@ -16,5 +16,15 @@ fi
 ## without resulting to symlinks.
 export PYTHONPATH="${PYTHONPATH}:${PWD}/custom_components"
 
+# Check if python-hilo exists and install it in development mode
+if [[ -d "/workspaces/python-hilo/pyhilo" ]]; then
+    echo "Installing custom version of python-hilo..."
+    pip install -e "/workspaces/python-hilo"
+    SKIP_PACKAGES="--skip-pip-packages python-hilo"
+else
+    echo "Using PyPI version of python-hilo..."
+    SKIP_PACKAGES=""
+fi
+
 # Start Home Assistant
-hass --config "${PWD}/config" --debug
+hass --config "${PWD}/config" --debug ${SKIP_PACKAGES}


### PR DESCRIPTION
This change modifies the development environment to allow working on both hilo and python-hilo repositories at the same time. The devcontainer configuration will mount the python-hilo repository if it exists and the develop script will install it in development mode.

Changes to `python-hilo` will be reflected when restarting Home assistant. You don't need to commit the code in `python-hilo` for the changes to reflect, as the whole folder is mounted and then installed with https://pip.pypa.io/en/stable/cli/pip_install/#install-editable