### PR TITLE
Small refactor to fix some lint errors

### DIFF
--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -9,10 +9,8 @@ from typing import TYPE_CHECKING, Union
 
 from homeassistant.components.select import (
     ATTR_OPTION,
-    SERVICE_SELECT_OPTION,
-)
-from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
 )
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
@@ -30,11 +28,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import (
     aiohttp_client,
     config_entry_oauth2_flow,
-)
-from homeassistant.helpers import (
     device_registry as dr,
-)
-from homeassistant.helpers import (
     entity_registry as er,
 )
 from homeassistant.helpers.dispatcher import (

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -242,7 +242,7 @@ class Hilo:
         )
         self.pre_cold = entry.options.get(
             CONF_PRE_COLD_PHASE,
-            DEFAULT_PRE_COLD_PHASE,  # this is new
+            DEFAULT_PRE_COLD_PHASE,
         )
         self.challenge_lock = entry.options.get(
             CONF_CHALLENGE_LOCK, DEFAULT_CHALLENGE_LOCK

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -1,4 +1,5 @@
 """Support for Hilo automation systems."""
+
 from __future__ import annotations
 
 import asyncio
@@ -8,8 +9,10 @@ from typing import TYPE_CHECKING, Union
 
 from homeassistant.components.select import (
     ATTR_OPTION,
-    DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
+)
+from homeassistant.components.select import (
+    DOMAIN as SELECT_DOMAIN,
 )
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
@@ -27,7 +30,11 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import (
     aiohttp_client,
     config_entry_oauth2_flow,
+)
+from homeassistant.helpers import (
     device_registry as dr,
+)
+from homeassistant.helpers import (
     entity_registry as er,
 )
 from homeassistant.helpers.dispatcher import (
@@ -240,7 +247,8 @@ class Hilo:
             CONF_APPRECIATION_PHASE, DEFAULT_APPRECIATION_PHASE
         )
         self.pre_cold = entry.options.get(
-            CONF_PRE_COLD_PHASE, DEFAULT_PRE_COLD_PHASE  # this is new
+            CONF_PRE_COLD_PHASE,
+            DEFAULT_PRE_COLD_PHASE,  # this is new
         )
         self.challenge_lock = entry.options.get(
             CONF_CHALLENGE_LOCK, DEFAULT_CHALLENGE_LOCK
@@ -787,7 +795,7 @@ class HiloEntity(CoordinatorEntity):
         hilo: Hilo,
         name: Union[str, None] = None,
         *,
-        device: HiloDevice | None = None,
+        device: HiloDevice,
     ) -> None:
         """Initialize."""
         assert hilo.coordinator

--- a/custom_components/hilo/switch.py
+++ b/custom_components/hilo/switch.py
@@ -4,6 +4,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify
+from pyhilo.device.switch import Switch
 
 from . import Hilo, HiloEntity
 from .const import DOMAIN, LOG, SWITCH_CLASSES
@@ -23,7 +24,7 @@ async def async_setup_entry(
 
 
 class HiloSwitch(HiloEntity, SwitchEntity):
-    def __init__(self, hilo: Hilo, device):
+    def __init__(self, hilo: Hilo, device: Switch):
         super().__init__(hilo, device=device, name=device.name)
         old_unique_id = f"{slugify(device.name)}-switch"
         self._attr_unique_id = f"{slugify(device.identifier)}-switch"


### PR DESCRIPTION
I'm starting to read the code and I see a lot of underlined code. This annoys me slightly, so I'll make a few small PR like this to try to tackle some of it :)

Starting small with switch.py:
- Add typing on `device` variable so that the properties can be referred to properly.
- Remove the `None` type of `HiloEntity` (in __init__.py:790). I feel like this should never be None? I tested it and there's no issue in my specific environment, this might require someone else to test it. This was needed otherwise the linter would complain that a null check need to be executed before a lot of things (and its right). Best make it required if we can.

 
There was also some changes in __init__.py that are being applied automatically (aggressively, I like it) by the dev container setup.
