### PR TITLE
Fix "referencing a non existing `via_device`" when gateway_external_id is None

### DIFF
--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -792,17 +792,18 @@ class HiloEntity(CoordinatorEntity):
         """Initialize."""
         assert hilo.coordinator
         super().__init__(hilo.coordinator)
+        device_info_args = {
+            "identifiers": {(DOMAIN, device.identifier)},
+            "manufacturer": device.manufacturer,
+            "model": device.model,
+            "name": device.name,
+        }
         try:
-            gateway = device.gateway_external_id
+            device_info_args["via_device"] = (DOMAIN, device.gateway_external_id)
         except AttributeError:
-            gateway = None
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, device.identifier)},
-            manufacturer=device.manufacturer,
-            model=device.model,
-            name=device.name,
-            via_device=(DOMAIN, gateway),
-        )
+            # If a device doesn't have a gateway_external_id, it's most likely the gateway itself.
+            pass  # Do nothing.
+        self._attr_device_info = DeviceInfo(**device_info_args)
         try:
             mac_address = dr.format_mac(device.sdi)
             self._attr_device_info[ATTR_CONNECTIONS] = {


### PR DESCRIPTION
I tested on my end adding some logging and the only case it seems to be missing is when the device is the gateway itself.

The fix is to simply not set `via_device` when `gateway_external_id` is `None`. It's not really useful to specify a `via_device` when the "device" would basically be itself when we're talking about the gateway itself.

From the HA documentation:
via_device: Identifier of a device that routes messages between this device and Home Assistant. Examples of such devices are hubs, or parent devices of a sub-device. This is used to show device topology in Home Assistant.
https://developers.home-assistant.io/docs/device_registry_index/#device-properties

This should fix #549.