### PR TITLE
ColorMode should be imported from homeassistant.components.light.const

### DIFF
--- a/custom_components/hilo/light.py
+++ b/custom_components/hilo/light.py
@@ -1,9 +1,5 @@
-from homeassistant.components.light import (
-    ATTR_BRIGHTNESS,
-    ATTR_HS_COLOR,
-    ColorMode,
-    LightEntity,
-)
+from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_HS_COLOR, LightEntity
+from homeassistant.components.light.const import ColorMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant


### PR DESCRIPTION
There was a lint error that we were importing it from the wrong place. I did a small change to move it to fix the warning.

The change in Home Assistant's side was done in https://github.com/home-assistant/core/pull/132473 two months ago.

I believe the plan is to mark as deprecated the non `.const` version in the near future.