### PR TITLE
Make devContainer more similar to Home Assistant environment

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,10 +1,16 @@
 {
   "name": "dvd-dev/hilo",
-  "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  "dockerFile": "Dockerfile.dev",
   // This is required because there is no conditional mount support in devcontainers.
   // We create the python-hilo directory if it doesn't exist.
   "initializeCommand": "mkdir -p ${localWorkspaceFolder}/../python-hilo || true",
   "postCreateCommand": "scripts/setup",
+  "containerEnv": {
+    "PYTHONASYNCIODEBUG": "1"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
   "forwardPorts": [8123],
   "portsAttributes": {
     "8123": {
@@ -16,28 +22,53 @@
     "vscode": {
       "extensions": [
         "charliermarsh.ruff",
-        "github.vscode-pull-request-github",
-        "ms-python.python",
+        "ms-python.pylint",
         "ms-python.vscode-pylance",
+        "visualstudioexptteam.vscodeintellicode",
+        "redhat.vscode-yaml",
+        "esbenp.prettier-vscode",
+        "github.vscode-pull-request-github",
         "ryanluker.vscode-coverage-gutters"
       ],
+      // Please keep this file in sync with settings in settings.default.json
       "settings": {
-        "files.eol": "\n",
-        "editor.tabSize": 4,
-        "editor.formatOnPaste": true,
+        "python.experiments.optOutFrom": ["pythonTestAdapter"],
+        //"python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.defaultInterpreterPath": "/home/vscode/.local/ha-venv/bin/python",
+        "python.pythonPath": "/home/vscode/.local/ha-venv/bin/python",
+        "python.terminal.activateEnvInCurrentTerminal": true,
+        "python.testing.pytestArgs": ["--no-cov"],
+        "pylint.importStrategy": "fromEnvironment",
+        "editor.formatOnPaste": false,
         "editor.formatOnSave": true,
-        "editor.formatOnType": false,
+        "editor.formatOnType": true,
         "files.trimTrailingWhitespace": true,
-        "python.analysis.typeCheckingMode": "basic",
-        "python.analysis.autoImportCompletions": true,
-        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "terminal.integrated.profiles.linux": {
+          "zsh": {
+            "path": "/usr/bin/zsh"
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "yaml.customTags": [
+          "!input scalar",
+          "!secret scalar",
+          "!include_dir_named scalar",
+          "!include_dir_list scalar",
+          "!include_dir_merge_list scalar",
+          "!include_dir_merge_named scalar"
+        ],
         "[python]": {
           "editor.defaultFormatter": "charliermarsh.ruff"
-        }
+        },
+        "json.schemas": [
+          {
+            "fileMatch": ["homeassistant/components/*/manifest.json"],
+            "url": "${containerWorkspaceFolder}/script/json_schemas/manifest_schema.json"
+          }
+        ]
       }
     }
   },
-  "remoteUser": "vscode",
   "mounts": [
     "source=${localWorkspaceFolder}/../python-hilo,target=/workspaces/python-hilo,type=bind,consistency=cached"
   ]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,69 @@
+# From https://github.com/home-assistant/core/blob/dev/Dockerfile.dev
+
+FROM mcr.microsoft.com/devcontainers/python:1-3.13
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Uninstall pre-installed formatting and linting tools
+# They would conflict with our pinned versions
+RUN \
+    pipx uninstall pydocstyle \
+    && pipx uninstall pycodestyle \
+    && pipx uninstall mypy \
+    && pipx uninstall pylint
+
+RUN \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        # Additional library needed by some tests and accordingly by VScode Tests Discovery
+        bluez \
+        ffmpeg \
+        libudev-dev \
+        libavformat-dev \
+        libavcodec-dev \
+        libavdevice-dev \
+        libavutil-dev \
+        libgammu-dev \
+        libswscale-dev \
+        libswresample-dev \
+        libavfilter-dev \
+        libpcap-dev \
+        libturbojpeg0 \
+        libyaml-dev \
+        libxml2 \
+        git \
+        cmake \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add go2rtc binary
+COPY --from=ghcr.io/alexxit/go2rtc:latest /usr/local/bin/go2rtc /bin/go2rtc
+
+# Install uv
+RUN pip3 install uv
+
+WORKDIR /usr/src
+
+# Setup hass-release
+RUN git clone --depth 1 https://github.com/home-assistant/hass-release \
+    && uv pip install --system -e hass-release/ \
+    && chown -R vscode /usr/src/hass-release/data
+
+USER vscode
+ENV VIRTUAL_ENV="/home/vscode/.local/ha-venv"
+RUN uv venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+WORKDIR /tmp
+
+# Install Python dependencies from requirements
+COPY requirements.txt ./
+RUN uv pip install -r requirements.txt
+COPY requirements_test.txt ./
+RUN uv pip install -r requirements_test.txt
+
+WORKDIR /workspaces
+
+# Set the default shell to bash instead of sh
+ENV SHELL /bin/bash

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,3 +4,4 @@ flake8>=4.0.1
 pre-commit>=2.16.0
 pyflakes>=2.4.0
 gitlint>=0.17.0
+pre-commit==4.0.0

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
+# Resolve all dependencies that the application requires to run.
 
+# Stop on errors
 set -e
 
 cd "$(dirname "$0")/.."
 
+echo "Installing development dependencies..."
 python3 -m pip install --requirement requirements.txt


### PR DESCRIPTION
This brings changes from Home assistant's devcontainer over so that the dev environment are more similar
https://github.com/home-assistant/core/blob/dev/.devcontainer/devcontainer.json

For example:
PYTHONASYNCIODEBUG - https://github.com/home-assistant/core/pull/115392
gh cli - https://github.com/home-assistant/core/pull/117321

This also adds some useful missing features, like the ability to run pre-commit checks directly on the devcontainer.

Future plans will be to add actual unit tests long term. 