### PR TITLE
Add test framework base

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,6 @@
+pytest
+pytest-cov
+pytest-homeassistant-custom-component
 bandit>=1.7.1
 black>=21.12b0
 flake8>=4.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,25 @@
+[coverage:run]
+source =
+  custom_components
+
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    raise NotImplemented()
+    if __name__ == '__main__':
+    main()
+show_missing = true
+
+[tool:pytest]
+testpaths = tests
+norecursedirs = .git
+asyncio_default_fixture_loop_scope = function
+asyncio_mode = auto
+addopts =
+    -p syrupy
+    --strict
+    --cov=custom_components
+
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
 doctests = True
@@ -34,9 +56,3 @@ default_section = THIRDPARTY
 known_first_party = custom_components.hilo, tests
 combine_as_imports = true
 
-[coverage:run]
-branch = False
-
-[coverage:report]
-show_missing = true
-fail_under = 100

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Hilo."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Fixtures for testing."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable custom integrations."""
+    return

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,10 @@
+"""Test component setup."""
+
+from homeassistant.setup import async_setup_component
+
+from custom_components.hilo.const import DOMAIN
+
+
+async def test_async_setup(hass):
+    """Test the component gets setup."""
+    assert await async_setup_component(hass, DOMAIN, {}) is True


### PR DESCRIPTION
Add the base to enable a test framework

This is mostly based on reading this article: https://aarongodfrey.dev/home%20automation/building_a_home_assistant_custom_component_part_2/

For now, the only test is checking that the setup was successful.