### PR TITLE
Remove daily schedule from GitHub Actions workflows.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,8 +6,6 @@ on:
       - main
       - dev
   pull_request:
-  schedule:
-    - cron: "0 0 * * *"
 
 env:
   DEFAULT_PYTHON: 3.9

--- a/github/workflows/hassfest.yaml
+++ b/github/workflows/hassfest.yaml
@@ -3,8 +3,6 @@ name: Validate with hassfest
 on:
   push:
   pull_request:
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
   validate:


### PR DESCRIPTION
The workflows for linting and hassfest were running daily. This commit removes the daily schedule and keeps only the push and pull request triggers. This change will save resources by not running the workflows if nothing changed. I also corrected a mistake that added a duplicate 'on: push:' in the tests.yaml file.