### PR TITLE
Handle errors loading the history state YAML file

### DIFF
--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -7,6 +7,8 @@ from datetime import datetime, timedelta, timezone
 from os.path import isfile
 
 import aiofiles
+import homeassistant.util.dt as dt_util
+import ruyaml as yaml
 from homeassistant.components.integration.sensor import METHOD_LEFT, IntegrationSensor
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -26,6 +28,8 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfSoundPressure,
     UnitOfTemperature,
+)
+from homeassistant.const import (
     __short_version__ as current_version,
 )
 from homeassistant.core import HomeAssistant
@@ -34,13 +38,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import Throttle, slugify
-import homeassistant.util.dt as dt_util
 from packaging.version import Version
 from pyhilo.const import UNMONITORED_DEVICES
 from pyhilo.device import HiloDevice
 from pyhilo.event import Event
 from pyhilo.util import from_utc_timestamp
-import ruyaml as yaml
 
 from . import Hilo, HiloEntity
 from .const import (
@@ -747,6 +749,10 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
                 LOG.debug("Loading history state from yaml")
                 content = await yaml_file.read()
                 history = yaml.load(content, Loader=yaml.Loader)
+                if not history:
+                    LOG.warning("History state is corrupted, resetting to default.")
+                    history = []
+
         return history
 
     async def _save_history(self, history: list):

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -749,7 +749,7 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
                 LOG.debug("Loading history state from yaml")
                 content = await yaml_file.read()
                 history = yaml.load(content, Loader=yaml.Loader)
-                if not history:
+                if not history or not isinstance(history, dict):
                     LOG.warning("History state is corrupted, resetting to default.")
                     history = []
 

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -43,6 +43,7 @@ from pyhilo.const import UNMONITORED_DEVICES
 from pyhilo.device import HiloDevice
 from pyhilo.event import Event
 from pyhilo.util import from_utc_timestamp
+from ruyaml.scanner import ScannerError
 
 from . import Hilo, HiloEntity
 from .const import (
@@ -748,9 +749,12 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
             async with aiofiles.open(self._history_state_yaml, mode="r") as yaml_file:
                 LOG.debug("Loading history state from yaml")
                 content = await yaml_file.read()
-                history = yaml.load(content, Loader=yaml.Loader)
+                try:
+                    history = yaml.load(content, Loader=yaml.Loader)
+                except ScannerError:
+                    LOG.error("History state YAML is corrupted, resetting to default.")
                 if not history or not isinstance(history, dict):
-                    LOG.warning("History state is corrupted, resetting to default.")
+                    LOG.error("History state YAML is invalid, resetting to default.")
                     history = []
 
         return history


### PR DESCRIPTION
Fixes an issue in the case that the history state yaml file exists, but is empty or corrupted.

```
2025-03-13 02:02:24.198 ERROR (MainThread) [homeassistant.helpers.entity] Update for sensor.recompenses_hilo fails
Traceback (most recent call last):
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/homeassistant/helpers/entity.py", line 960, in async_update_ha_state
    await self.async_device_update()
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/homeassistant/helpers/entity.py", line 1318, in async_device_update
    await self.async_update()
  File "/workspaces/hilo/custom_components/hilo/sensor.py", line 693, in _async_update
    for item in current_history
                ^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```
