### PR TITLE
Add missing virtual env activation in develop script

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,6 @@
 # From https://github.com/home-assistant/core/blob/dev/Dockerfile.dev
+# This gets us an environment as close as possible to the default Home Assistant
+# dev environment.
 
 FROM mcr.microsoft.com/devcontainers/python:1-3.13
 
@@ -16,7 +18,7 @@ RUN \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        # Additional library needed by some tests and accordingly by VScode Tests Discovery
+        # Additional library needed by Home Assistant to simulate a real environment
         bluez \
         ffmpeg \
         libudev-dev \

--- a/scripts/develop
+++ b/scripts/develop
@@ -4,6 +4,9 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+# Activate the virtual environment
+source "${VIRTUAL_ENV}/bin/activate"
+
 # Create config dir if not present
 if [[ ! -d "${PWD}/config" ]]; then
     mkdir -p "${PWD}/config"
@@ -19,7 +22,7 @@ export PYTHONPATH="${PYTHONPATH}:${PWD}/custom_components"
 # Check if python-hilo exists and install it in development mode
 if [[ -d "/workspaces/python-hilo/pyhilo" ]]; then
     echo "Installing custom version of python-hilo..."
-    pip install -e "/workspaces/python-hilo"
+    uv pip install -e "/workspaces/python-hilo"
     SKIP_PACKAGES="--skip-pip-packages python-hilo"
 else
     echo "Using PyPI version of python-hilo..."


### PR DESCRIPTION
This should fix issues like the following in the dev container:

> [homeassistant.config_entries] Error occurred loading flow for integration hilo: No module named 'pyhilo'
