### PR TITLE
Add debounce when saving the event history state

### DIFF
--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -5,7 +5,7 @@ import asyncio
 from collections import OrderedDict
 from datetime import datetime, timedelta
 import traceback
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from homeassistant.components.select import (
     ATTR_OPTION,
@@ -15,7 +15,6 @@ from homeassistant.components.select import (
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_CONNECTIONS,
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_SCAN_INTERVAL,
@@ -31,16 +30,10 @@ from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
 )
-from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect,
-    async_dispatcher_send,
-)
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.entity import DeviceInfo  # noqa
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from pyhilo import API
 from pyhilo.device import HiloDevice
 from pyhilo.devices import Devices

--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -5,7 +5,7 @@ import asyncio
 from collections import OrderedDict
 from datetime import datetime, timedelta
 import traceback
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from homeassistant.components.select import (
     ATTR_OPTION,
@@ -15,6 +15,7 @@ from homeassistant.components.select import (
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    ATTR_CONNECTIONS,
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_SCAN_INTERVAL,
@@ -30,10 +31,16 @@ from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
 )
-from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.entity import DeviceInfo  # noqa
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 from pyhilo import API
 from pyhilo.device import HiloDevice
 from pyhilo.devices import Devices

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -784,6 +784,7 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
             # main event loop
             await yaml_file.write(yaml.dump(history))
 
+
 class HiloChallengeSensor(HiloEntity, SensorEntity):
     """Hilo challenge sensor.
     Its state will be either:

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -7,8 +7,6 @@ from datetime import datetime, timedelta, timezone
 from os.path import isfile
 
 import aiofiles
-import homeassistant.util.dt as dt_util
-import ruyaml as yaml
 from homeassistant.components.integration.sensor import METHOD_LEFT, IntegrationSensor
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -28,8 +26,6 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfSoundPressure,
     UnitOfTemperature,
-)
-from homeassistant.const import (
     __short_version__ as current_version,
 )
 from homeassistant.core import HomeAssistant
@@ -39,11 +35,13 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import Throttle, slugify
+import homeassistant.util.dt as dt_util
 from packaging.version import Version
 from pyhilo.const import UNMONITORED_DEVICES
 from pyhilo.device import HiloDevice
 from pyhilo.event import Event
 from pyhilo.util import from_utc_timestamp
+import ruyaml as yaml
 from ruyaml.scanner import ScannerError
 
 from . import Hilo

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -7,6 +7,8 @@ from datetime import datetime, timedelta, timezone
 from os.path import isfile
 
 import aiofiles
+import homeassistant.util.dt as dt_util
+import yaml
 from homeassistant.components.integration.sensor import METHOD_LEFT, IntegrationSensor
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -26,6 +28,8 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfSoundPressure,
     UnitOfTemperature,
+)
+from homeassistant.const import (
     __short_version__ as current_version,
 )
 from homeassistant.core import HomeAssistant
@@ -35,13 +39,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import Throttle, slugify
-import homeassistant.util.dt as dt_util
 from packaging.version import Version
 from pyhilo.const import UNMONITORED_DEVICES
 from pyhilo.device import HiloDevice
 from pyhilo.event import Event
 from pyhilo.util import from_utc_timestamp
-import yaml
 from yaml.scanner import ScannerError
 
 from . import Hilo
@@ -782,7 +784,8 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
             # to the file in a non blocking manner. Currently, the file writes
             # are properly async but the yaml dump is done synchroniously on the
             # main event loop
-            await yaml_file.write(yaml.dump(history))
+            await yaml_file.write(yaml.dump(self._history))
+
 
 
 class HiloChallengeSensor(HiloEntity, SensorEntity):

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -7,8 +7,6 @@ from datetime import datetime, timedelta, timezone
 from os.path import isfile
 
 import aiofiles
-import homeassistant.util.dt as dt_util
-import yaml
 from homeassistant.components.integration.sensor import METHOD_LEFT, IntegrationSensor
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -28,8 +26,6 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfSoundPressure,
     UnitOfTemperature,
-)
-from homeassistant.const import (
     __short_version__ as current_version,
 )
 from homeassistant.core import HomeAssistant
@@ -39,11 +35,13 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import Throttle, slugify
+import homeassistant.util.dt as dt_util
 from packaging.version import Version
 from pyhilo.const import UNMONITORED_DEVICES
 from pyhilo.device import HiloDevice
 from pyhilo.event import Event
 from pyhilo.util import from_utc_timestamp
+import yaml
 from yaml.scanner import ScannerError
 
 from . import Hilo
@@ -785,7 +783,6 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
             # are properly async but the yaml dump is done synchroniously on the
             # main event loop
             await yaml_file.write(yaml.dump(self._history))
-
 
 
 class HiloChallengeSensor(HiloEntity, SensorEntity):

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -33,6 +33,7 @@ from homeassistant.const import (
     __short_version__ as current_version,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
@@ -616,6 +617,21 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
         self.async_update = Throttle(self.scan_interval)(self._async_update)
         hilo.register_websocket_listener(self)
 
+        # When we update the list of reward history, we can end up making
+        # hundreds of calls to _save_history in a very short amount of time.
+        # With a debouncer, we can reduce this to a single save, which is more
+        # efficient (save can become pretty slow when the history is long) and
+        # makes sure Home Assistant is not slowed down. Some websocket could
+        # even lose connection due to the delay introduced by saving many times.
+        LOG.debug("Setting up debouncer for history saver")
+        self._save_history_debouncer = Debouncer(
+            hilo._hass,
+            LOG,
+            cooldown=5,  # Wait for 5 seconds before writing to file
+            immediate=False,
+            function=self._save_history,
+        )
+
     @property
     def state(self):
         return self._state
@@ -671,7 +687,7 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
                                 season["events"], key=lambda x: int(x["event_id"])
                             )
                         ]
-                        await self._save_history(self._history)
+                        await self._save_history_debouncer.async_call()
                         return
                 LOG.debug(f"ChallengeId did not match, appending: {event['event_id']}")
                 season["events"].append(event)
@@ -681,7 +697,8 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
                         season["events"], key=lambda x: int(x["event_id"])
                     )
                 ]
-                await self._save_history(self._history)
+
+        await self._save_history_debouncer.async_call()
 
     async def _async_update(self):
         seasons = await self._hilo._api.get_seasons(self._hilo.devices.location_id)
@@ -740,7 +757,7 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
                 new_history.append(season)
 
             self._history = new_history
-            await self._save_history(new_history)
+            await self._save_history_debouncer.async_call()
             for eventId in self._events_to_poll:
                 await self._hilo.subscribe_to_challenge(1, eventId)
 
@@ -760,10 +777,10 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
 
         return history
 
-    async def _save_history(self, history: list):
+    async def _save_history(self):
         async with aiofiles.open(self._history_state_yaml, mode="w") as yaml_file:
             LOG.debug("Saving history state to yaml file")
-            await yaml_file.write(yaml.dump(history, Dumper=yaml.RoundTripDumper))
+            await yaml_file.write(yaml.dump(self._history, Dumper=yaml.RoundTripDumper))
 
 
 class HiloChallengeSensor(HiloEntity, SensorEntity):

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -7,6 +7,8 @@ from datetime import datetime, timedelta, timezone
 from os.path import isfile
 
 import aiofiles
+import homeassistant.util.dt as dt_util
+import ruyaml as yaml
 from homeassistant.components.integration.sensor import METHOD_LEFT, IntegrationSensor
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -26,6 +28,8 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfSoundPressure,
     UnitOfTemperature,
+)
+from homeassistant.const import (
     __short_version__ as current_version,
 )
 from homeassistant.core import HomeAssistant
@@ -35,13 +39,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import Throttle, slugify
-import homeassistant.util.dt as dt_util
 from packaging.version import Version
 from pyhilo.const import UNMONITORED_DEVICES
 from pyhilo.device import HiloDevice
 from pyhilo.event import Event
 from pyhilo.util import from_utc_timestamp
-import ruyaml as yaml
 from ruyaml.scanner import ScannerError
 
 from . import Hilo


### PR DESCRIPTION
Without debounce, my home assistant would end up saving the file more than 200 times in a row. Each file save could take up to 200ms to write  ~88kb. 

The write part is not too bad, it is done async. However, dumping the python object to YAML is done synchronously on the main event loop thread which could end up blocking most other IO events, including websocket connections. This would sometimes cause issue with go2rtc library, hilo websockets and other Home assistant processes.

With the debounce, the file is saved only once after we are done gathering all the data. This gives a much nicer experience to the user when the data is retrieved. It doesn't happen often but it's still nice.