### PR TITLE
Bump up pyhilo version, code quality

### DIFF
--- a/custom_components/hilo/manifest.json
+++ b/custom_components/hilo/manifest.json
@@ -11,6 +11,6 @@
   "documentation": "https://github.com/dvd-dev/hilo",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dvd-dev/hilo/issues",
-  "requirements": ["python-hilo>=2025.6.2"],
-  "version": "2025.9.1"
+  "requirements": ["python-hilo>=2025.9.1"],
+  "version": "2025.9.2"
 }


### PR DESCRIPTION
Bump up pyhilo version. This will make sure hilo and python hilo use lazy formatting for debug logging, which should reduce overhead.