### PR TITLE
Update python-hilo

### DIFF
--- a/custom_components/hilo/manifest.json
+++ b/custom_components/hilo/manifest.json
@@ -11,6 +11,6 @@
   "documentation": "https://github.com/dvd-dev/hilo",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dvd-dev/hilo/issues",
-  "requirements": ["python-hilo>=2025.10.1"],
-  "version": "2025.10.1"
+  "requirements": ["python-hilo>=2025.10.2"],
+  "version": "2025.10.2"
 }


### PR DESCRIPTION
Bump up pyhilo [2025.10.2](https://github.com/dvd-dev/python-hilo/releases/tag/v2025.10.2) pour PR[#336](https://github.com/dvd-dev/python-hilo/pull/336).

Ne pas merger, build pyhilo pas fait.

Corrige la valeur de brightness des dimmers.