### PR TITLE
Fix de doc pour l'ancrage PM

### DIFF
--- a/doc/automations/Défi_Hilo_Ancrage_PM.yaml
+++ b/doc/automations/Défi_Hilo_Ancrage_PM.yaml
@@ -28,7 +28,7 @@ triggers:
       seconds: 0
   - entity_id:
       - sensor.defi_hilo
-    to: 
+    to:
       - appreciation
     trigger: state
     id: Sensor
@@ -58,7 +58,7 @@ conditions:
         state: scheduled
       - condition: state
         entity_id: sensor.defi_hilo
-        state: pre_cold        
+        state: pre_cold
   - condition: time
     after: "11:55:00"
     before: "12:05:00"


### PR DESCRIPTION
Premier PR ever sur un projet publique pour moi! :)

Suite aux derniers changement à l'ancrage PM, ça n'a pas déclanché pour le premier défi PM chez moi.
La raison pourquoi est qu'on arrivait du state "pre_cold" et non pas "completed|scheduled".

J'ai donc ajouté cet autre state qui existe (je ne sais pas s'il est encore bien utilisé cependant).

Sinon, je m'interroge aussi à l'ancrage AM, sa structure/logique est différente. Je n'ai pas cherché à l'uniformisé, car il y a p-e une raison, mais je crois que ce serait à évaluer.