### PR TITLE
QOL fix, ajout des états du sensor hilo dans le dropdown. Fix partiel kwh

### DIFF
--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -347,7 +347,10 @@ class Hilo:
             msg_type = "challenge_added"
         elif target == "ChallengeDetailsUpdated":
             msg_type = "challenge_details_update"
-        elif target == "ChallengeConsumptionUpdatedValuesReceived":
+        elif target in [
+            "ChallengeConsumptionUpdatedValuesReceived",
+            "EventCHConsumptionUpdatedValuesReceived",
+        ]:
             msg_type = "challenge_details_update"
         elif target in [
             "ChallengeDetailsUpdatedValuesReceived",
@@ -367,7 +370,6 @@ class Hilo:
         ]:
             msg_type = "challenge_details_update"
         elif target in [
-            "EventCHConsumptionUpdatedValuesReceived",
             "EventFlexConsumptionUpdatedValuesReceived",
         ]:
             LOG.debug("%s message received", target)

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -993,6 +993,8 @@ class HiloChallengeSensor(HiloEntity, SensorEntity):
                     updated_event.pre_cold(self._hilo.pre_cold)
                 if baselinewH > 0:
                     updated_event.update_allowed_wh(baselinewH)
+                elif current_event.allowed_kWh > 0:
+                    updated_event.allowed_kWh = current_event.allowed_kWh
                 self._events[event_id] = updated_event
             self._update_next_events()
 


### PR DESCRIPTION
Ajout des états du sensor défi possibles afin qu'ils soient visibles lorsqu'on créée des automatisations.