### PR TITLE
Meilleure méthode de unique_id (prérequis pour supporter la suppression)

### DIFF
--- a/custom_components/hilo/climate.py
+++ b/custom_components/hilo/climate.py
@@ -70,9 +70,14 @@ class HiloClimate(HiloEntity, ClimateEntity):
         """Initialize the climate entity."""
         super().__init__(hilo, device=device, name=device.name)
         old_unique_id = f"{slugify(device.name)}-climate"
-        self._attr_unique_id = f"{slugify(device.identifier)}-climate"
+        self._attr_unique_id = f"{device.identifier.lower()}-climate"
         hilo.async_migrate_unique_id(
             old_unique_id, self._attr_unique_id, Platform.CLIMATE
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-climate",
+            self._attr_unique_id,
+            Platform.CLIMATE,
         )
         self.operations = [HVACMode.HEAT]
         self._has_operation = False

--- a/custom_components/hilo/light.py
+++ b/custom_components/hilo/light.py
@@ -35,9 +35,12 @@ class HiloLight(HiloEntity, LightEntity):
         """Initialize the Hilo light entity."""
         super().__init__(hilo, device=device, name=device.name)
         old_unique_id = f"{slugify(device.name)}-light"
-        self._attr_unique_id = f"{slugify(device.identifier)}-light"
+        self._attr_unique_id = f"{device.identifier.lower()}-light"
         hilo.async_migrate_unique_id(
             old_unique_id, self._attr_unique_id, Platform.LIGHT
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-light", self._attr_unique_id, Platform.LIGHT
         )
         self._debounced_turn_on = Debouncer(
             hass,

--- a/custom_components/hilo/sensor.py
+++ b/custom_components/hilo/sensor.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
     __short_version__ as current_version,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -223,9 +224,14 @@ class BatterySensor(HiloEntity, SensorEntity):
         self._attr_name = f"{device.name} Battery"
         super().__init__(hilo, name=self._attr_name, device=device)
         old_unique_id = f"{slugify(device.name)}-battery"
-        self._attr_unique_id = f"{slugify(device.identifier)}-battery"
+        self._attr_unique_id = f"{device.identifier.lower()}-battery"
         hilo.async_migrate_unique_id(
             old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-battery",
+            self._attr_unique_id,
+            Platform.SENSOR,
         )
         LOG.debug("Setting up BatterySensor entity: %s", self._attr_name)
 
@@ -257,9 +263,12 @@ class Co2Sensor(HiloEntity, SensorEntity):
         self._attr_name = f"{device.name} CO2"
         super().__init__(hilo, name=self._attr_name, device=device)
         old_unique_id = f"{slugify(device.name)}-co2"
-        self._attr_unique_id = f"{slugify(device.identifier)}-co2"
+        self._attr_unique_id = f"{device.identifier.lower()}-co2"
         hilo.async_migrate_unique_id(
             old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-co2", self._attr_unique_id, Platform.SENSOR
         )
         LOG.debug("Setting up CO2Sensor entity: %s", self._attr_name)
 
@@ -291,16 +300,31 @@ class EnergySensor(IntegrationSensor):
         self._device = device
         self._attr_name = f"{device.name} Hilo Energy"
         old_unique_id = f"hilo_energy_{slugify(device.name)}"
-        self._attr_unique_id = f"{slugify(device.identifier)}-energy"
+        self._attr_unique_id = f"{device.identifier.lower()}-energy"
         hilo.async_migrate_unique_id(
             old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-energy",
+            self._attr_unique_id,
+            Platform.SENSOR,
         )
         self._unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
         self._suggested_display_precision = 2
 
         if device.type == "Meter":
             self._attr_name = HILO_ENERGY_TOTAL
-        self._source = f"sensor.{slugify(device.name)}_power"
+
+        power_unique_id = f"{device.identifier.lower()}-power"
+        entity_registry = er.async_get(hass)
+        self._source = next(
+            (
+                entry.entity_id
+                for entry in entity_registry.entities.values()
+                if entry.unique_id == power_unique_id and entry.platform == DOMAIN
+            ),
+            f"sensor.{slugify(device.name)}_power",  # fallback
+        )
         # ic-dev21: Set initial state and last_valid_state, removes log errors and unavailable states
         initial_state = 0
         self._attr_native_value = initial_state
@@ -381,9 +405,12 @@ class NoiseSensor(HiloEntity, SensorEntity):
         self._attr_name = f"{device.name} Noise"
         super().__init__(hilo, name=self._attr_name, device=device)
         old_unique_id = f"{slugify(device.name)}-noise"
-        self._attr_unique_id = f"{slugify(device.identifier)}-noise"
+        self._attr_unique_id = f"{device.identifier.lower()}-noise"
         hilo.async_migrate_unique_id(
             old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-noise", self._attr_unique_id, Platform.SENSOR
         )
         LOG.debug("Setting up NoiseSensor entity: %s", self._attr_name)
 
@@ -414,9 +441,12 @@ class PowerSensor(HiloEntity, SensorEntity):
         self._attr_name = f"{device.name} Power"
         super().__init__(hilo, name=self._attr_name, device=device)
         old_unique_id = f"{slugify(device.name)}-power"
-        self._attr_unique_id = f"{slugify(device.identifier)}-power"
+        self._attr_unique_id = f"{device.identifier.lower()}-power"
         hilo.async_migrate_unique_id(
             old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-power", self._attr_unique_id, Platform.SENSOR
         )
         LOG.debug("Setting up PowerSensor entity: %s", self._attr_name)
 
@@ -448,9 +478,14 @@ class TemperatureSensor(HiloEntity, SensorEntity):
         self._attr_name = f"{device.name} Temperature"
         super().__init__(hilo, name=self._attr_name, device=device)
         old_unique_id = f"{slugify(device.name)}-temperature"
-        self._attr_unique_id = f"{slugify(device.identifier)}-temperature"
+        self._attr_unique_id = f"{device.identifier.lower()}-temperature"
         hilo.async_migrate_unique_id(
             old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-temperature",
+            self._attr_unique_id,
+            Platform.SENSOR,
         )
         LOG.debug("Setting up TemperatureSensor entity: %s", self._attr_name)
 
@@ -486,9 +521,14 @@ class TargetTemperatureSensor(HiloEntity, SensorEntity):
         self._attr_name = f"{device.name} Target Temperature"
         super().__init__(hilo, name=self._attr_name, device=device)
         old_unique_id = f"{slugify(device.name)}-target-temperature"
-        self._attr_unique_id = f"{slugify(device.identifier)}-target-temperature"
+        self._attr_unique_id = f"{device.identifier.lower()}-target-temperature"
         hilo.async_migrate_unique_id(
             old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-target-temperature",
+            self._attr_unique_id,
+            Platform.SENSOR,
         )
         LOG.debug("Setting up TargetTemperatureSensor entity: %s", self._attr_name)
 
@@ -523,7 +563,11 @@ class WifiStrengthSensor(HiloEntity, SensorEntity):
         """Hilo Wi-Fi strength sensor initialization."""
         self._attr_name = f"{device.name} WifiStrength"
         super().__init__(hilo, name=self._attr_name, device=device)
-        self._attr_unique_id = f"{slugify(device.name)}-wifistrength"
+        old_unique_id = f"{slugify(device.name)}-wifistrength"
+        self._attr_unique_id = f"{device.identifier.lower()}-wifistrength"
+        hilo.async_migrate_unique_id(
+            old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
         LOG.debug("Setting up WifiStrengthSensor entity: %s", self._attr_name)
 
     @property
@@ -557,11 +601,14 @@ class HiloNotificationSensor(HiloEntity, RestoreEntity, SensorEntity):
         self._attr_name = "Notifications Hilo"
         super().__init__(hilo, name=self._attr_name, device=device)
         old_unique_id = slugify(self._attr_name)
-        self._attr_unique_id = (
-            f"{slugify(device.identifier)}-{slugify(self._attr_name)}"
-        )
+        self._attr_unique_id = f"{device.identifier.lower()}-{slugify(self._attr_name)}"
         hilo.async_migrate_unique_id(
             old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-{slugify(self._attr_name)}",
+            self._attr_unique_id,
+            Platform.SENSOR,
         )
         LOG.debug("Setting up NotificationSensor entity: %s", self._attr_name)
         self.scan_interval = timedelta(seconds=NOTIFICATION_SCAN_INTERVAL)
@@ -647,11 +694,14 @@ class HiloRewardSensor(HiloEntity, RestoreEntity, SensorEntity):
 
         super().__init__(hilo, name=self._attr_name, device=device)
         old_unique_id = slugify(self._attr_name)
-        self._attr_unique_id = (
-            f"{slugify(device.identifier)}-{slugify(self._attr_name)}"
-        )
+        self._attr_unique_id = f"{device.identifier.lower()}-{slugify(self._attr_name)}"
         hilo.async_migrate_unique_id(
             old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-{slugify(self._attr_name)}",
+            self._attr_unique_id,
+            Platform.SENSOR,
         )
         LOG.debug("Setting up RewardSensor entity: %s", self._attr_name)
         self._history_state_yaml: str = "hilo_eventhistory_state.yaml"
@@ -898,11 +948,14 @@ class HiloChallengeSensor(HiloEntity, SensorEntity):
         ]
         super().__init__(hilo, name=self._attr_name, device=device)
         old_unique_id = slugify(self._attr_name)
-        self._attr_unique_id = (
-            f"{slugify(device.identifier)}-{slugify(self._attr_name)}"
-        )
+        self._attr_unique_id = f"{device.identifier.lower()}-{slugify(self._attr_name)}"
         hilo.async_migrate_unique_id(
             old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-{slugify(self._attr_name)}",
+            self._attr_unique_id,
+            Platform.SENSOR,
         )
         LOG.debug("Setting up ChallengeSensor entity: %s", self._attr_name)
         self.scan_interval = timedelta(seconds=EVENT_SCAN_INTERVAL_REDUCTION)
@@ -1131,9 +1184,14 @@ class DeviceSensor(HiloEntity, SensorEntity):
         self._attr_name = device.name
         super().__init__(hilo, name=self._attr_name, device=device)
         old_unique_id = slugify(device.name)
-        self._attr_unique_id = f"{slugify(device.identifier)}-{slugify(device.name)}"
+        self._attr_unique_id = f"{device.identifier.lower()}-{slugify(device.name)}"
         hilo.async_migrate_unique_id(
             old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-{slugify(device.name)}",
+            self._attr_unique_id,
+            Platform.SENSOR,
         )
         LOG.debug("Setting up DeviceSensor entity: %s", self._attr_name)
 
@@ -1181,11 +1239,14 @@ class HiloCostSensor(HiloEntity, SensorEntity):
         self._last_update = dt_util.utcnow()
         self._cost = amount
         old_unique_id = slugify(self._attr_name)
-        self._attr_unique_id = (
-            f"{slugify(device.identifier)}-{slugify(self._attr_name)}"
-        )
+        self._attr_unique_id = f"{device.identifier.lower()}-{slugify(self._attr_name)}"
         hilo.async_migrate_unique_id(
             old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-{slugify(self._attr_name)}",
+            self._attr_unique_id,
+            Platform.SENSOR,
         )
         self._last_update = dt_util.utcnow()
         super().__init__(hilo, name=self._attr_name, device=device)
@@ -1260,8 +1321,15 @@ class HiloOutdoorTempSensor(HiloEntity, SensorEntity):
         """Initialize."""
         self._attr_name = "Outdoor Weather Hilo"
         super().__init__(hilo, name=self._attr_name, device=device)
-        self._attr_unique_id = (
-            f"{slugify(device.identifier)}-{slugify(self._attr_name)}"
+        old_unique_id = slugify(self._attr_name)
+        self._attr_unique_id = f"{device.identifier.lower()}-{slugify(self._attr_name)}"
+        hilo.async_migrate_unique_id(
+            old_unique_id, self._attr_unique_id, Platform.SENSOR
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-{slugify(self._attr_name)}",
+            self._attr_unique_id,
+            Platform.SENSOR,
         )
         LOG.debug("Setting up OutdoorWeatherSensor entity: %s", self._attr_name)
         self.scan_interval = timedelta(seconds=WEATHER_SCAN_INTERVAL)

--- a/custom_components/hilo/switch.py
+++ b/custom_components/hilo/switch.py
@@ -34,9 +34,14 @@ class HiloSwitch(HiloEntity, SwitchEntity):
         """Initialize the switch."""
         super().__init__(hilo, device=device, name=device.name)
         old_unique_id = f"{slugify(device.name)}-switch"
-        self._attr_unique_id = f"{slugify(device.identifier)}-switch"
+        self._attr_unique_id = f"{device.identifier.lower()}-switch"
         hilo.async_migrate_unique_id(
             old_unique_id, self._attr_unique_id, Platform.SWITCH
+        )
+        hilo.async_migrate_unique_id(
+            f"{slugify(device.identifier)}-switch",
+            self._attr_unique_id,
+            Platform.SWITCH,
         )
         LOG.debug("Setting up Switch entity: %s", self._attr_name)
 


### PR DESCRIPTION
On va se baser sur un unique id qui gère mieux les hyphen et underscore, on est basés sur le mac address partout. Ce commit devrait permettre de renommer des device dans Hilo sans tout péter. Les power sensors/energy sensors sont aussi liés au device identifier plutôt qu'au nom, donc les renommer ne devrait pas tout péter non plus.

Ça se veut une étape préalable à être capable de supprimer des devices du service Hilo, ou les renommer dans l'app etc. sans que tout brise dans HA.