### PR TITLE
Manage timeout issues when connecting to the API (when no Internet at startup)

### DIFF
--- a/custom_components/hilo/__init__.py
+++ b/custom_components/hilo/__init__.py
@@ -169,6 +169,9 @@ async def async_setup_entry(  # noqa: C901
         await hilo.async_init(scan_interval)
     except HiloError as err:
         raise ConfigEntryNotReady from err
+    except (TimeoutError, client_exceptions.ClientError) as err:
+        LOG.debug("Timeout with API connection")
+        raise ConfigEntryNotReady from err
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = hilo


### PR DESCRIPTION
Fixes an issue where a connection timeout during an API call permanently stalls the Home Assistant component, preventing it from automatically recovering. This behavior is highly similar to the issue addressed in #750.